### PR TITLE
Optimize base branch coverage calculation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -141,6 +141,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
+        if: steps.base_cache.outputs.cache-hit != 'true'
 
       - name: Restore cached base coverage
         id: base_cache


### PR DESCRIPTION
Add caching for base branch coverage to prevent recalculating the same coverage numbers on every PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4ced851-c376-4632-9824-ae2c947298e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4ced851-c376-4632-9824-ae2c947298e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

