### PR TITLE
fix(docker): pass SMTP environment variables to containers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,12 @@ services:
             - BETTER_AUTH_TRUSTED_ORIGINS=${BETTER_AUTH_TRUSTED_ORIGINS}
             - CORS_ORIGINS=${CORS_ORIGINS}
             - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+            - SMTP_HOST=${SMTP_HOST}
+            - SMTP_PORT=${SMTP_PORT}
+            - SMTP_SECURE=${SMTP_SECURE}
+            - SMTP_USER=${SMTP_USER}
+            - SMTP_PASS=${SMTP_PASS}
+            - SMTP_FROM=${SMTP_FROM}
         networks:
             - constellate-network
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,12 @@ services:
             - BETTER_AUTH_SECRET=app1-secret-change-in-production
             - BETTER_AUTH_TRUSTED_ORIGINS=http://app1.local
             - ENCRYPTION_KEY_FILE=/app/.keys/.encryption-key
+            - SMTP_HOST=${SMTP_HOST}
+            - SMTP_PORT=${SMTP_PORT}
+            - SMTP_SECURE=${SMTP_SECURE}
+            - SMTP_USER=${SMTP_USER}
+            - SMTP_PASS=${SMTP_PASS}
+            - SMTP_FROM=${SMTP_FROM}
         volumes:
             - .:/app
             - /app/node_modules
@@ -84,6 +90,12 @@ services:
             - BETTER_AUTH_SECRET=app2-secret-change-in-production
             - BETTER_AUTH_TRUSTED_ORIGINS=http://app2.local
             - ENCRYPTION_KEY_FILE=/app/.keys/.encryption-key
+            - SMTP_HOST=${SMTP_HOST}
+            - SMTP_PORT=${SMTP_PORT}
+            - SMTP_SECURE=${SMTP_SECURE}
+            - SMTP_USER=${SMTP_USER}
+            - SMTP_PASS=${SMTP_PASS}
+            - SMTP_FROM=${SMTP_FROM}
         volumes:
             - .:/app
             - /app/node_modules


### PR DESCRIPTION
## Summary
- Added `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM` to the environment variables passed to the `app` service in `docker-compose.prod.yml`.
- Also added them to `app1` and `app2` in `docker-compose.yml` for consistency in development.

## Motivation
The application was failing to send emails ("SMTP not configured") because these environment variables were not being forwarded from the host's `.env` file to the Docker container.