### PR TITLE
🎨 Palette: Add Clear Button to Search Bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-26 - Interactive Input Icons
+**Learning:** `Input` components often block pointer events on icons (`pointer-events-none`) for layout stability, but this prevents useful patterns like "Clear" or "Show Password" buttons.
+**Action:** Extend `Input` components to support an `onRightIconClick` prop that conditionally renders the icon wrapper as an accessible `<button>` instead of a `<div>`, ensuring keyboard accessibility and proper focus management.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,17 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<CloseIcon className="w-4 h-4" />
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +199,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				onRightIconClick={!isLoading && query ? handleClear : undefined}
+				rightIconAriaLabel="Clear search"
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,16 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Callback when right icon is clicked.
+	 * If provided, rightIcon renders as an interactive button.
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * Aria label for the right icon button.
+	 * Required if onRightIconClick is provided.
+	 */
+	rightIconAriaLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +65,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconAriaLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -152,17 +164,32 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 						aria-required={required}
 						{...props}
 					/>
-					{rightIcon && (
-						<div
-							className={cn(
-								'absolute right-3 top-1/2 -translate-y-1/2',
-								'text-text-disabled',
-								'pointer-events-none',
-								error && 'text-error-500 dark:text-error-400'
-							)}>
-							{rightIcon}
-						</div>
-					)}
+					{rightIcon &&
+						(onRightIconClick ? (
+							<button
+								type="button"
+								onClick={onRightIconClick}
+								aria-label={rightIconAriaLabel}
+								disabled={disabled}
+								className={cn(
+									'absolute right-3 top-1/2 -translate-y-1/2',
+									'text-text-disabled hover:text-text-primary transition-colors',
+									'focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-primary-500 rounded-sm',
+									error && 'text-error-500 dark:text-error-400'
+								)}>
+								{rightIcon}
+							</button>
+						) : (
+							<div
+								className={cn(
+									'absolute right-3 top-1/2 -translate-y-1/2',
+									'text-text-disabled',
+									'pointer-events-none',
+									error && 'text-error-500 dark:text-error-400'
+								)}>
+								{rightIcon}
+							</div>
+						))}
 				</div>
 				{error && errorMessage && (
 					<p

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,39 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should render interactive right icon when onRightIconClick is provided', () => {
+		const handleRightIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleRightIconClick}
+				rightIconAriaLabel="Clear input"
+			/>
+		)
+
+		const button = screen.getByLabelText('Clear input')
+		expect(button).toBeInTheDocument()
+		expect(button.tagName).toBe('BUTTON')
+
+		fireEvent.click(button)
+		expect(handleRightIconClick).toHaveBeenCalledTimes(1)
+	})
+
+	it('should disable interactive right icon when input is disabled', () => {
+		const handleRightIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				disabled
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleRightIconClick}
+				rightIconAriaLabel="Clear input"
+			/>
+		)
+
+		const button = screen.getByLabelText('Clear input')
+		expect(button).toBeDisabled()
+	})
 })


### PR DESCRIPTION
💡 What: Added an interactive clear button ("X") to the Search Bar that appears when there is text input.
🎯 Why: Users had to manually delete text to clear a search, which is tedious. This provides a quick way to reset the search.
📸 Before/After: Verified via Playwright screenshots.
♿ Accessibility:
    - Added `onRightIconClick` support to `Input` component to render interactive icons as accessible buttons.
    - Added `aria-label="Clear search"` to the clear button.
    - Refocuses the input after clearing for seamless keyboard navigation.

---
*PR created automatically by Jules for task [5760451095160381996](https://jules.google.com/task/5760451095160381996) started by @burnoutberni*