### PR TITLE
⚡ Bolt: Memoize FeedPage list rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 
 **Learning:** `CalendarView` re-renders all event buttons when `userAttendingEventIds` changes because the event click handler was recreated on every render, invalidating `React.memo` if it were used.
 **Action:** When optimizing list rendering, ensure callback props are stable (using `useCallback` or `useMemo`) so `React.memo` on list items is effective.
+
+## 2025-02-14 - FeedPage Zod Validation Re-renders
+
+**Learning:** Zod schema validation (`safeParse`) creates new object references on every execution; therefore, performing validation inside a React render loop will invalidate `React.memo` on child components unless the validation result or the rendered output is memoized.
+**Action:** Memoize the result of data mapping/validation using `useMemo` so that stable object references are passed to children.

--- a/client/src/pages/FeedPage.tsx
+++ b/client/src/pages/FeedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { z } from 'zod'
 
 import { CreateEventModal } from '@/components/CreateEventModal'
@@ -119,7 +119,85 @@ export function FeedPage() {
 		)
 	}
 
-	const allItems = data?.pages?.flatMap((page: { items: FeedItem[], nextCursor?: string }) => page.items) || []
+	const feedContent = useMemo(() => {
+		const items = data?.pages?.flatMap((page: { items: FeedItem[], nextCursor?: string }) => page.items) || []
+
+		if (items.length === 0) {
+			return (
+				<Card variant="default" padding="lg" className="text-center">
+					<h3 className="text-lg font-medium text-text-primary mb-2">Welcome!</h3>
+					<p className="text-text-secondary">Follow people to see their activity here.</p>
+				</Card>
+			)
+		}
+
+		return items.map((item: FeedItem) => {
+			const key = `${item.type}-${item.id}`
+
+			switch (item.type) {
+				case 'header': {
+					const validated = getValidatedData(HeaderSchema, item.data, 'header')
+					if (validated) {
+						const { title } = validated
+						return (
+							<div key={key} className="pt-4 pb-2">
+								<h2 className="text-lg font-semibold text-text-primary border-b border-border-default pb-2">
+									{title}
+								</h2>
+							</div>
+						)
+					}
+					return null
+				}
+
+				case 'onboarding': {
+					const validated = getValidatedData(SuggestedUsersSchema, item.data, 'onboarding')
+					if (validated) {
+						return <OnboardingHero key={key} suggestions={validated.suggestions} />
+					}
+					return null
+				}
+
+				case 'suggested_users': {
+					const validated = getValidatedData(SuggestedUsersSchema, item.data, 'suggested_users')
+					if (validated) {
+						return <SuggestedUsersCard key={key} users={validated.suggestions} />
+					}
+					return null
+				}
+
+				case 'trending_event': {
+					const validated = getValidatedData(EventSchema, item.data, 'trending_event')
+					if (validated) {
+						return (
+							<div key={key} className="h-full">
+								<EventCard event={validated} isAuthenticated={Boolean(user)} />
+							</div>
+						)
+					}
+					return null
+				}
+
+				case 'activity': {
+					const validated = getValidatedData(ActivitySchema, item.data, 'activity')
+					if (validated) {
+						// For "Smart Agenda", we show the Event itself
+						return (
+							<div key={key} className="h-full">
+								{validated.event && <EventCard event={validated.event} isAuthenticated={Boolean(user)} />}
+							</div>
+						)
+					}
+					return null
+				}
+
+				default:
+					return null
+			}
+		})
+	}, [data, user])
+
+	const hasItems = data?.pages?.some(p => p.items.length > 0)
 
 	return (
 		<div className="min-h-screen bg-background-secondary">
@@ -152,77 +230,7 @@ export function FeedPage() {
 							</div>
 						)}
 
-						{allItems.length === 0 ? (
-							<Card variant="default" padding="lg" className="text-center">
-								<h3 className="text-lg font-medium text-text-primary mb-2">Welcome!</h3>
-								<p className="text-text-secondary">Follow people to see their activity here.</p>
-							</Card>
-						) : (
-							allItems.map((item: FeedItem) => {
-								const key = `${item.type}-${item.id}`
-
-								switch (item.type) {
-									case 'header': {
-										const validated = getValidatedData(HeaderSchema, item.data, 'header')
-										if (validated) {
-											const { title } = validated
-											return (
-												<div key={key} className="pt-4 pb-2">
-													<h2 className="text-lg font-semibold text-text-primary border-b border-border-default pb-2">
-														{title}
-													</h2>
-												</div>
-											)
-										}
-										return null
-									}
-
-									case 'onboarding': {
-										const validated = getValidatedData(SuggestedUsersSchema, item.data, 'onboarding')
-										if (validated) {
-											return <OnboardingHero key={key} suggestions={validated.suggestions} />
-										}
-										return null
-									}
-
-									case 'suggested_users': {
-										const validated = getValidatedData(SuggestedUsersSchema, item.data, 'suggested_users')
-										if (validated) {
-											return <SuggestedUsersCard key={key} users={validated.suggestions} />
-										}
-										return null
-									}
-
-									case 'trending_event': {
-										const validated = getValidatedData(EventSchema, item.data, 'trending_event')
-										if (validated) {
-											return (
-												<div key={key} className="h-full">
-													<EventCard event={validated} isAuthenticated={Boolean(user)} />
-												</div>
-											)
-										}
-										return null
-									}
-
-									case 'activity': {
-										const validated = getValidatedData(ActivitySchema, item.data, 'activity')
-										if (validated) {
-											// For "Smart Agenda", we show the Event itself
-											return (
-												<div key={key} className="h-full">
-													{validated.event && <EventCard event={validated.event} isAuthenticated={Boolean(user)} />}
-												</div>
-											)
-										}
-										return null
-									}
-
-									default:
-										return null
-								}
-							})
-						)}
+						{feedContent}
 					</div>
 
 					{/* Load More Trigger */}
@@ -232,7 +240,7 @@ export function FeedPage() {
 						</div>
 					)}
 
-					{!hasNextPage && allItems.length > 0 && (
+					{!hasNextPage && hasItems && (
 						<p className="text-center text-sm text-text-tertiary mt-8 mb-8">
 							You&apos;ve reached the end of your agenda.
 						</p>

--- a/client/src/tests/pages/FeedPage.perf.test.tsx
+++ b/client/src/tests/pages/FeedPage.perf.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { FeedPage } from '../../pages/FeedPage'
+import { createTestWrapper, clearQueryClient } from '../testUtils'
+
+// Mock dependencies
+const mockUser = { id: 'user1', username: 'testuser', name: 'Test User' }
+
+const mockEvent = {
+	id: 'event1',
+	title: 'Test Event',
+	summary: 'Test summary',
+	startTime: '2024-01-15T10:00:00Z',
+	endTime: '2024-01-15T12:00:00Z',
+	visibility: 'PUBLIC',
+	tags: [],
+	user: {
+		id: 'user1',
+		username: 'testuser',
+		name: 'Test User',
+		isRemote: false,
+	},
+	_count: {
+		attendance: 10,
+		likes: 5,
+		comments: 3,
+	},
+	timezone: 'UTC'
+}
+
+// We need to access the mock calls to check props
+const mockEventCard = vi.fn()
+
+const mockUseHomeFeed = vi.fn()
+const mockUseAuth = vi.fn()
+const mockUseUIStore = vi.fn()
+
+vi.mock('../../hooks/useAuth', () => ({
+	useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../../hooks/queries', async () => {
+	const actual = await vi.importActual('../../hooks/queries')
+	return {
+		...actual,
+		useHomeFeed: () => mockUseHomeFeed(),
+	}
+})
+
+vi.mock('../../stores', () => ({
+	useUIStore: () => mockUseUIStore(),
+}))
+
+// Mock EventCard to spy on props
+vi.mock('../../components/EventCard', () => ({
+	EventCard: (props: any) => {
+		mockEventCard(props)
+		return <div data-testid="event-card">{props.event.title}</div>
+	},
+}))
+
+// Mock other components to avoid rendering noise
+vi.mock('../../components/CreateEventModal', () => ({
+	CreateEventModal: ({ isOpen }: { isOpen: boolean }) => (
+		isOpen ? <div data-testid="create-event-modal">Modal Open</div> : null
+	),
+}))
+vi.mock('../../components/Feed/Sidebar', () => ({ Sidebar: () => null }))
+vi.mock('../../components/Navbar', () => ({ Navbar: () => null }))
+vi.mock('../../components/Feed/OnboardingHero', () => ({ OnboardingHero: () => null }))
+vi.mock('../../components/Feed/SuggestedUsersCard', () => ({ SuggestedUsersCard: () => null }))
+
+const { wrapper, queryClient } = createTestWrapper(['/feed'])
+
+describe('FeedPage Performance', () => {
+	beforeEach(() => {
+		clearQueryClient(queryClient)
+		vi.clearAllMocks()
+		mockUseAuth.mockReturnValue({
+			user: mockUser,
+			logout: vi.fn(),
+		})
+		mockUseHomeFeed.mockReturnValue({
+			data: {
+				pages: [{
+					items: [{
+						type: 'trending_event',
+						id: 'activity1',
+						timestamp: '2024-01-15T10:00:00Z',
+						data: mockEvent
+					}]
+				}]
+			},
+			isLoading: false,
+			hasNextPage: false,
+			isFetchingNextPage: false,
+			status: 'success'
+		})
+		mockUseUIStore.mockReturnValue({
+			sseConnected: true,
+			isFeedRefreshing: false
+		})
+	})
+
+	it('preserves event card stability on re-render with optimization', async () => {
+		render(<FeedPage />, { wrapper })
+
+		// Initial render
+		expect(mockEventCard).toHaveBeenCalledTimes(1)
+		const firstRenderEvent = mockEventCard.mock.calls[0][0].event
+
+		// Trigger re-render by opening modal (state change)
+		const newEventButton = screen.getByText(/New Event/i)
+		fireEvent.click(newEventButton)
+
+		// Wait for re-render
+		await waitFor(() => {
+			expect(screen.getByTestId('create-event-modal')).toBeInTheDocument()
+		})
+
+		// Should NOT have rendered again (or if it did, props should be identical)
+		// Because we memoized the list, React sees the same elements and skips rendering
+		expect(mockEventCard).toHaveBeenCalledTimes(1)
+
+		// If for some reason it did render (e.g. context change), ensure props are stable
+		if (mockEventCard.mock.calls.length > 1) {
+			const secondRenderEvent = mockEventCard.mock.calls[1][0].event
+			expect(secondRenderEvent).toBe(firstRenderEvent)
+		}
+	})
+})


### PR DESCRIPTION
⚡ Bolt: Memoize FeedPage list rendering

💡 What: Wrapped the feed item generation logic (including Zod validation) in `useMemo`.
🎯 Why: `FeedPage` re-renders when local state (e.g., "New Event" modal) changes. The previous implementation re-ran `Zod.safeParse` for every item on every render, creating new object references. This caused all `EventCard` components to receive new props and re-render unnecessarily.
📊 Impact: Eliminates Zod validation overhead and child component re-renders during state updates.
🔬 Measurement: Verified with `client/src/tests/pages/FeedPage.perf.test.tsx` which asserts that `EventCard` props remain referentially stable across re-renders.

---
*PR created automatically by Jules for task [10388559195827637553](https://jules.google.com/task/10388559195827637553) started by @burnoutberni*