### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Federation Handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-27 - Missing Sanitization in ActivityPub Ingestion
+**Vulnerability:** Incoming ActivityPub data (events, comments, profiles) was stored raw in the database without HTML sanitization, leading to Stored XSS risks if other clients rendered it unsafely.
+**Learning:** The application relied entirely on frontend sanitization (`SafeHTML`), violating the defense-in-depth principle. Federated protocols often carry rich text, making them a high-risk vector for XSS.
+**Prevention:** Always sanitize rich text inputs at the API/Service boundary using a strict allowlist (like DOMPurify) before storage, ensuring the backend is the source of truth for safe content.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -15,6 +15,7 @@ import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
 import { prisma } from './lib/prisma.js'
+import { sanitizeHtml, sanitizeText } from './lib/sanitization.js'
 import { trackInstance } from './lib/instanceHelpers.js'
 import { logger } from './lib/logger.js'
 import type { Prisma, Event, User } from '@prisma/client'
@@ -507,12 +508,17 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
 	const getNumber = (val: unknown) => (typeof val === 'number' ? val : null)
 
+	const rawName = getString(eventObj.name) || ''
+	const rawSummary = getString(eventObj.summary)
+	const rawContent = getString(eventObj.content)
+	const rawLocation = getLocationValue(eventObj.location)
+
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: sanitizeText(rawName),
+		eventSummary: rawSummary ? sanitizeHtml(rawSummary) : null,
+		eventContent: rawContent ? sanitizeHtml(rawContent) : null,
+		locationValue: rawLocation ? sanitizeText(rawLocation) : null,
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -786,7 +792,8 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const rawContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = sanitizeHtml(rawContent)
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,22 +900,23 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const eventName = typeof eventObj.name === 'string' ? sanitizeText(eventObj.name) : ''
+	const eventSummary =
+		typeof eventObj.summary === 'string' ? sanitizeHtml(eventObj.summary) : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
 	const eventLocation = eventObj.location
 	let locationValue: string | null
 	if (typeof eventLocation === 'string') {
-		locationValue = eventLocation
+		locationValue = sanitizeText(eventLocation)
 	} else if (
 		eventLocation &&
 		isNonNullObject(eventLocation) &&
 		'name' in eventLocation &&
 		typeof eventLocation.name === 'string'
 	) {
-		locationValue = eventLocation.name
+		locationValue = sanitizeText(eventLocation.name)
 	} else {
 		locationValue = null
 	}
@@ -945,8 +953,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeHtml(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -16,3 +16,48 @@ export function sanitizeText(input: string): string {
 		ALLOWED_ATTR: [],
 	})
 }
+
+// DOMPurify configuration for safe HTML sanitization
+// This allows common formatting tags like <p>, <strong>, <em>, <br>, <a>, etc.
+// but blocks dangerous tags like <script>, <iframe>, etc.
+// Matches client/src/components/ui/SafeHTML.tsx
+const HTML_CONFIG = {
+	ALLOWED_TAGS: [
+		'p',
+		'br',
+		'strong',
+		'b',
+		'em',
+		'i',
+		'u',
+		's',
+		'strike',
+		'del',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'ul',
+		'ol',
+		'li',
+		'a',
+		'blockquote',
+		'pre',
+		'code',
+		'span',
+		'div',
+	],
+	ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+	ALLOWED_URI_REGEXP: /^(https?:|mailto:|tel:|\/)/i,
+}
+
+/**
+ * Sanitizes HTML content (preserves safe tags)
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML with only allowed tags/attributes
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, HTML_CONFIG)
+}

--- a/src/tests/federation.security.test.ts
+++ b/src/tests/federation.security.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Security Tests for Federation Handlers
+ * Verifies that incoming ActivityPub content is properly sanitized to prevent Stored XSS.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { config } from 'dotenv'
+config()
+import { handleActivity } from '../federation.js'
+import { ActivityType, ObjectType } from '../constants/activitypub.js'
+import { prisma } from '../lib/prisma.js'
+import * as activitypubHelpers from '../lib/activitypubHelpers.js'
+import * as realtime from '../realtime.js'
+
+// Mock dependencies
+vi.mock('../lib/activitypubHelpers.js')
+vi.mock('../services/ActivityBuilder.js')
+vi.mock('../services/ActivityDelivery.js')
+vi.mock('../realtime.js')
+
+describe('Federation Security (XSS Prevention)', () => {
+	let testUser: any
+
+	beforeEach(async () => {
+		// Clean up processed activities and data
+		await prisma.processedActivity.deleteMany({})
+		await prisma.event.deleteMany({})
+		await prisma.comment.deleteMany({})
+		await prisma.user.deleteMany({})
+
+		// Reset mocks
+		vi.clearAllMocks()
+	})
+
+	describe('Event Sanitization', () => {
+		it('should sanitize event fields on Create activity', async () => {
+			const remoteActor = {
+				id: 'https://example.com/users/evil',
+				type: 'Person',
+				preferredUsername: 'evil',
+				inbox: 'https://example.com/users/evil/inbox',
+			}
+
+			const remoteUser = await prisma.user.create({
+				data: {
+					username: 'evil@example.com',
+					email: 'evil@example.com',
+					name: 'Evil',
+					isRemote: true,
+					externalActorUrl: remoteActor.id,
+					inboxUrl: remoteActor.inbox,
+				},
+			})
+
+			vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+			vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+			vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+			const maliciousEvent = {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/xss-1',
+				name: 'Safe Title <script>alert(1)</script>',
+				summary: '<b>Bold</b> <img src=x onerror=alert(1)>',
+				content: '<p>Para</p> <iframe src="javascript:alert(1)"></iframe>',
+				location: 'Safe Loc <script>alert(1)</script>',
+				startTime: new Date().toISOString(),
+			}
+
+			const activity = {
+				id: 'https://example.com/activities/create-xss-1',
+				type: ActivityType.CREATE,
+				actor: remoteActor.id,
+				object: maliciousEvent,
+			}
+
+			await handleActivity(activity as any)
+
+			const event = await prisma.event.findFirst({
+				where: { externalId: maliciousEvent.id },
+			})
+
+			expect(event).toBeTruthy()
+			// Title should be plain text (stripped completely)
+			expect(event?.title).toBe('Safe Title ') // sanitizeText removes all tags
+			// Summary should be safe HTML
+			expect(event?.summary).toBe('<b>Bold</b> ') // img is NOT in ALLOWED_TAGS, so it is stripped.
+
+			// Location should be plain text
+			expect(event?.location).toBe('Safe Loc ')
+		})
+
+        it('should strip images and scripts but keep safe formatting', async () => {
+			const remoteActor = {
+				id: 'https://example.com/users/xss',
+				type: 'Person',
+			}
+            const remoteUser = await prisma.user.create({
+				data: {
+					username: 'xss@example.com',
+                    isRemote: true,
+					externalActorUrl: remoteActor.id,
+				},
+			})
+
+			vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+			vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+            const activity = {
+				id: 'https://example.com/activities/create-xss-2',
+				type: ActivityType.CREATE,
+				actor: remoteActor.id,
+				object: {
+                    type: ObjectType.EVENT,
+                    id: 'https://example.com/events/xss-2',
+                    name: 'Test',
+                    startTime: new Date().toISOString(),
+                    // This contains allowed tags (b, i) and disallowed (script, img)
+                    summary: '<b>Safe</b> <script>bad()</script> <i>Also Safe</i> <img src=x>',
+                },
+			}
+
+            await handleActivity(activity as any)
+
+            const event = await prisma.event.findFirst({
+				where: { externalId: 'https://example.com/events/xss-2' },
+			})
+
+            // Expect strict sanitization based on ALLOWED_TAGS
+            expect(event?.summary).toBe('<b>Safe</b>  <i>Also Safe</i> ')
+        })
+	})
+
+	describe('Comment (Note) Sanitization', () => {
+		it('should sanitize comment content on Create activity', async () => {
+            const remoteActor = { id: 'https://example.com/users/troll', type: 'Person' }
+            const remoteUser = await prisma.user.create({
+				data: {
+					username: 'troll@example.com',
+                    isRemote: true,
+					externalActorUrl: remoteActor.id,
+				},
+			})
+            // Create event to comment on
+            const event = await prisma.event.create({
+                data: {
+                    title: 'Test Event',
+                    startTime: new Date(),
+                    externalId: 'https://example.com/events/target',
+                    attributedTo: 'https://example.com/users/victim',
+                }
+            })
+
+			vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+			vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+			const activity = {
+				id: 'https://example.com/activities/create-note-xss',
+				type: ActivityType.CREATE,
+				actor: remoteActor.id,
+				object: {
+					type: ObjectType.NOTE,
+					id: 'https://example.com/comments/xss',
+					content: '<a href="javascript:alert(1)">Bad Link</a> <a href="https://good.com">Good Link</a>',
+					inReplyTo: event.externalId,
+				},
+			}
+
+			await handleActivity(activity as any)
+
+			const comment = await prisma.comment.findFirst({
+				where: { externalId: activity.object.id },
+			})
+
+			expect(comment).toBeTruthy()
+            // javascript: href should be stripped or the link removed
+            // DOMPurify with ALLOWED_URI_REGEXP should strip the href or the tag if it fails validation
+            // The default config I copied strips javascript: URIs.
+			expect(comment?.content).not.toContain('javascript:alert')
+            expect(comment?.content).toContain('Bad Link') // The text remains
+            expect(comment?.content).toContain('href="https://good.com"')
+		})
+	})
+
+    describe('Profile Update Sanitization', () => {
+        it('should sanitize user profile fields on Update activity', async () => {
+            const remoteUser = await prisma.user.create({
+				data: {
+					username: 'updater@example.com',
+                    isRemote: true,
+					externalActorUrl: 'https://example.com/users/updater',
+                    name: 'Old Name',
+                    bio: 'Old Bio',
+				},
+			})
+
+            const activity = {
+				id: 'https://example.com/activities/update-profile-xss',
+				type: ActivityType.UPDATE,
+				actor: remoteUser.externalActorUrl,
+				object: {
+					type: ObjectType.PERSON,
+					id: remoteUser.externalActorUrl,
+                    name: 'New <b>Name</b>', // Should be plain text
+                    summary: 'New <b>Bio</b> <script>alert(1)</script>', // Should be safe HTML
+				},
+			}
+
+            await handleActivity(activity as any)
+
+            const updatedUser = await prisma.user.findUnique({
+                where: { id: remoteUser.id }
+            })
+
+            expect(updatedUser?.name).toBe('New Name') // sanitizeText strips <b>
+            expect(updatedUser?.bio).toBe('New <b>Bio</b> ') // sanitizeHtml keeps <b>, removes script
+        })
+    })
+})


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Prevent Stored XSS in Federation

🚨 Severity: HIGH
💡 Vulnerability: Incoming ActivityPub data (events, comments, profiles) was stored raw in the database without sanitization. This allowed Stored XSS if the data contained malicious HTML (e.g., `<script>`) and was rendered by a client (though the current frontend uses `SafeHTML`, other clients or future changes might not).
🎯 Impact: Attackers could inject scripts to steal sessions, perform actions on behalf of users, or deface the site for anyone viewing the malicious content.
🔧 Fix:
1.  Added `sanitizeHtml` to `src/lib/sanitization.ts` using `isomorphic-dompurify`.
2.  Applied sanitization to all rich text ingestion points in `src/federation.ts`.
✅ Verification:
- Added `src/tests/federation.security.test.ts` which confirms that `<script>` tags and `javascript:` links are stripped, while safe tags like `<b>` are preserved.
- Ran existing federation tests to ensure no regressions.

---
*PR created automatically by Jules for task [2339419443863304441](https://jules.google.com/task/2339419443863304441) started by @burnoutberni*