### PR TITLE
⚡ Bolt: Memoize FeedPage items to reduce re-renders

### DIFF
--- a/client/src/pages/FeedPage.tsx
+++ b/client/src/pages/FeedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { z } from 'zod'
 
 import { CreateEventModal } from '@/components/CreateEventModal'
@@ -79,6 +79,92 @@ export function FeedPage() {
 	}, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
 
+	const allItems = useMemo(
+		() =>
+			data?.pages?.flatMap(
+				(page: { items: FeedItem[]; nextCursor?: string }) => page.items
+			) || [],
+		[data]
+	)
+
+	const feedContent = useMemo(() => {
+		if (allItems.length === 0) {
+			return (
+				<Card variant="default" padding="lg" className="text-center">
+					<h3 className="text-lg font-medium text-text-primary mb-2">Welcome!</h3>
+					<p className="text-text-secondary">Follow people to see their activity here.</p>
+				</Card>
+			)
+		}
+
+		return allItems.map((item: FeedItem) => {
+			const key = `${item.type}-${item.id}`
+
+			switch (item.type) {
+				case 'header': {
+					const validated = getValidatedData(HeaderSchema, item.data, 'header')
+					if (validated) {
+						const { title } = validated
+						return (
+							<div key={key} className="pt-4 pb-2">
+								<h2 className="text-lg font-semibold text-text-primary border-b border-border-default pb-2">
+									{title}
+								</h2>
+							</div>
+						)
+					}
+					return null
+				}
+
+				case 'onboarding': {
+					const validated = getValidatedData(SuggestedUsersSchema, item.data, 'onboarding')
+					if (validated) {
+						return <OnboardingHero key={key} suggestions={validated.suggestions} />
+					}
+					return null
+				}
+
+				case 'suggested_users': {
+					const validated = getValidatedData(SuggestedUsersSchema, item.data, 'suggested_users')
+					if (validated) {
+						return <SuggestedUsersCard key={key} users={validated.suggestions} />
+					}
+					return null
+				}
+
+				case 'trending_event': {
+					const validated = getValidatedData(EventSchema, item.data, 'trending_event')
+					if (validated) {
+						return (
+							<div key={key} className="h-full">
+								<EventCard event={validated} isAuthenticated={Boolean(user)} />
+							</div>
+						)
+					}
+					return null
+				}
+
+				case 'activity': {
+					const validated = getValidatedData(ActivitySchema, item.data, 'activity')
+					if (validated) {
+						// For "Smart Agenda", we show the Event itself
+						return (
+							<div key={key} className="h-full">
+								{validated.event && (
+									<EventCard event={validated.event} isAuthenticated={Boolean(user)} />
+								)}
+							</div>
+						)
+					}
+					return null
+				}
+
+				default:
+					return null
+			}
+		})
+	}, [allItems, user])
+
 	// If not authenticated, the query is disabled so status stays pending/idle
 	// We only show loading spinner if we are explicitly loading (isFetching)
 	// OR if we are authenticated (so we expect data eventually)
@@ -119,8 +205,6 @@ export function FeedPage() {
 		)
 	}
 
-	const allItems = data?.pages?.flatMap((page: { items: FeedItem[], nextCursor?: string }) => page.items) || []
-
 	return (
 		<div className="min-h-screen bg-background-secondary">
 			<Navbar isConnected={sseConnected} user={user} onLogout={logout} />
@@ -152,77 +236,7 @@ export function FeedPage() {
 							</div>
 						)}
 
-						{allItems.length === 0 ? (
-							<Card variant="default" padding="lg" className="text-center">
-								<h3 className="text-lg font-medium text-text-primary mb-2">Welcome!</h3>
-								<p className="text-text-secondary">Follow people to see their activity here.</p>
-							</Card>
-						) : (
-							allItems.map((item: FeedItem) => {
-								const key = `${item.type}-${item.id}`
-
-								switch (item.type) {
-									case 'header': {
-										const validated = getValidatedData(HeaderSchema, item.data, 'header')
-										if (validated) {
-											const { title } = validated
-											return (
-												<div key={key} className="pt-4 pb-2">
-													<h2 className="text-lg font-semibold text-text-primary border-b border-border-default pb-2">
-														{title}
-													</h2>
-												</div>
-											)
-										}
-										return null
-									}
-
-									case 'onboarding': {
-										const validated = getValidatedData(SuggestedUsersSchema, item.data, 'onboarding')
-										if (validated) {
-											return <OnboardingHero key={key} suggestions={validated.suggestions} />
-										}
-										return null
-									}
-
-									case 'suggested_users': {
-										const validated = getValidatedData(SuggestedUsersSchema, item.data, 'suggested_users')
-										if (validated) {
-											return <SuggestedUsersCard key={key} users={validated.suggestions} />
-										}
-										return null
-									}
-
-									case 'trending_event': {
-										const validated = getValidatedData(EventSchema, item.data, 'trending_event')
-										if (validated) {
-											return (
-												<div key={key} className="h-full">
-													<EventCard event={validated} isAuthenticated={Boolean(user)} />
-												</div>
-											)
-										}
-										return null
-									}
-
-									case 'activity': {
-										const validated = getValidatedData(ActivitySchema, item.data, 'activity')
-										if (validated) {
-											// For "Smart Agenda", we show the Event itself
-											return (
-												<div key={key} className="h-full">
-													{validated.event && <EventCard event={validated.event} isAuthenticated={Boolean(user)} />}
-												</div>
-											)
-										}
-										return null
-									}
-
-									default:
-										return null
-								}
-							})
-						)}
+						{feedContent}
 					</div>
 
 					{/* Load More Trigger */}


### PR DESCRIPTION
💡 **What**: Implemented `useMemo` for `allItems` (the flattened feed list) and `feedContent` (the rendered list of components) in `FeedPage.tsx`.

🎯 **Why**: Previously, `FeedPage` re-calculated the flattened list and re-ran Zod schema validation (`safeParse`) for every item on *every* render. This caused performance overhead and forced re-renders of all child components (like `EventCard`) whenever any local state changed (e.g., toggling a modal, background data refetching).

📊 **Impact**: 
- Reduces unnecessary Zod validations by preventing them when feed data hasn't changed.
- Prevents re-creation of `EventCard` components, allowing React to skip DOM diffing for the feed list during unrelated state updates.

🔬 **Measurement**: 
- Verified with `client/src/tests/pages/FeedPage.test.tsx`.
- Visual inspection of code confirms `useMemo` dependencies are correct (`[data]` for items, `[allItems, user]` for content).

---
*PR created automatically by Jules for task [18188059497326715863](https://jules.google.com/task/18188059497326715863) started by @burnoutberni*