### PR TITLE
🎨 Palette: Add focus trap to Modal component

### DIFF
--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -119,6 +119,64 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 			}
 		}, [isOpen])
 
+		// Trap focus within modal
+		useEffect(() => {
+			if (!isOpen) {
+				return
+			}
+
+			const previousActiveElement = document.activeElement as HTMLElement
+			const modalElement = contentRef.current
+			if (!modalElement) {
+				return
+			}
+
+			const focusableSelector =
+				'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+			// Focus first element on open
+			const initialFocusableElements =
+				modalElement.querySelectorAll(focusableSelector)
+			if (initialFocusableElements.length > 0) {
+				;(initialFocusableElements[0] as HTMLElement).focus()
+			}
+
+			function handleTabKey(e: KeyboardEvent) {
+				if (e.key !== 'Tab') {
+					return
+				}
+
+				const currentFocusableElements =
+					modalElement.querySelectorAll(focusableSelector)
+				if (currentFocusableElements.length === 0) {
+					return
+				}
+
+				const firstElement = currentFocusableElements[0] as HTMLElement
+				const lastElement = currentFocusableElements[
+					currentFocusableElements.length - 1
+				] as HTMLElement
+
+				if (e.shiftKey) {
+					if (document.activeElement === firstElement) {
+						lastElement.focus()
+						e.preventDefault()
+					}
+				} else {
+					if (document.activeElement === lastElement) {
+						firstElement.focus()
+						e.preventDefault()
+					}
+				}
+			}
+
+			document.addEventListener('keydown', handleTabKey)
+			return () => {
+				document.removeEventListener('keydown', handleTabKey)
+				previousActiveElement?.focus()
+			}
+		}, [isOpen])
+
 		if (!isOpen) {
 			return null
 		}

--- a/client/src/tests/components/Modal.test.tsx
+++ b/client/src/tests/components/Modal.test.tsx
@@ -140,4 +140,39 @@ describe('Modal Component', () => {
 		await user.keyboard('{Escape}')
 		expect(mockOnClose).not.toHaveBeenCalled()
 	})
+
+	it('traps focus within the modal when open', async () => {
+		const user = userEvent.setup()
+		render(
+			<Modal isOpen={true} onClose={mockOnClose}>
+				<button>Button 1</button>
+				<button>Button 2</button>
+				<button>Button 3</button>
+			</Modal>,
+			{ wrapper }
+		)
+
+		const button1 = screen.getByText('Button 1')
+		const button2 = screen.getByText('Button 2')
+		const button3 = screen.getByText('Button 3')
+
+		// Set initial focus
+		button1.focus()
+
+		// Tab to button 2
+		await user.tab()
+		expect(button2).toHaveFocus()
+
+		// Tab to button 3
+		await user.tab()
+		expect(button3).toHaveFocus()
+
+		// Tab should cycle back to button 1
+		await user.tab()
+		expect(button1).toHaveFocus()
+
+		// Shift+Tab should cycle back to button 3
+		await user.tab({ shift: true })
+		expect(button3).toHaveFocus()
+	})
 })


### PR DESCRIPTION
💡 What: Added focus trapping logic to the Modal component.
🎯 Why: To improve accessibility for keyboard users by preventing focus from escaping the modal.
♿ Accessibility: Implements WCAG 2.1 focus management requirements. Focus is trapped within the modal when open and restored to the trigger element when closed.
Verified with existing tests and a new reproduction test case.

---
*PR created automatically by Jules for task [16318590658851242129](https://jules.google.com/task/16318590658851242129) started by @burnoutberni*