### PR TITLE
🎨 Palette: Add interactive clear button to SearchBar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-19 - Interactive Input Icons
+**Learning:** The `Input` component originally used `pointer-events-none` for all icons, preventing interactivity.
+**Action:** Use `onRightIconClick` and `rightIconAriaLabel` props on `Input` to enable interactive icons (like clear buttons or password toggles) that are accessible and keyboard navigable.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,17 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<CloseIcon className="w-4 h-4" />
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +199,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				onRightIconClick={!isLoading && query ? handleClear : undefined}
+				rightIconAriaLabel="Clear search"
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,16 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Callback when the right icon is clicked.
+	 * Makes the icon interactive and accessible as a button.
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * ARIA label for the right icon button when it is interactive.
+	 * Required if onRightIconClick is provided.
+	 */
+	rightIconAriaLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +65,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconAriaLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -156,11 +168,32 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 						<div
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
-								'text-text-disabled',
-								'pointer-events-none',
-								error && 'text-error-500 dark:text-error-400'
+								onRightIconClick ? 'pointer-events-auto' : 'pointer-events-none'
 							)}>
-							{rightIcon}
+							{onRightIconClick ? (
+								<button
+									type="button"
+									onClick={onRightIconClick}
+									aria-label={rightIconAriaLabel}
+									disabled={disabled}
+									className={cn(
+										'flex items-center justify-center rounded-full p-1 -m-1 transition-colors',
+										'focus:outline-none focus:ring-2 focus:ring-primary-500',
+										error
+											? 'text-error-500 dark:text-error-400 hover:bg-error-50 dark:hover:bg-error-900/20'
+											: 'text-text-disabled hover:text-text-primary hover:bg-neutral-100 dark:hover:bg-neutral-800'
+									)}>
+									{rightIcon}
+								</button>
+							) : (
+								<span
+									className={cn(
+										'flex items-center',
+										error ? 'text-error-500 dark:text-error-400' : 'text-text-disabled'
+									)}>
+									{rightIcon}
+								</span>
+							)}
 						</div>
 					)}
 				</div>

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,21 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should handle right icon click when onRightIconClick is provided', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleClick}
+				rightIconAriaLabel="Clear"
+			/>
+		)
+
+		const button = screen.getByRole('button', { name: 'Clear' })
+		fireEvent.click(button)
+
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
 })


### PR DESCRIPTION
Implemented a micro-UX improvement by adding a "Clear" button to the SearchBar.
- Modified `client/src/components/ui/Input.tsx` to allow interactive right icons (previously `pointer-events-none`).
- Updated `client/src/components/SearchBar.tsx` to show a `CloseIcon` when text is present, allowing users to clear the search with one click.
- Ensured keyboard accessibility and focus restoration.
- Verified with unit tests and frontend screenshot verification.

---
*PR created automatically by Jules for task [7148009593840263158](https://jules.google.com/task/7148009593840263158) started by @burnoutberni*