### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Interactive Icons in Input Fields
+**Learning:** `Input` component previously enforced `pointer-events-none` on right icons, preventing interactivity.
+**Action:** Use the new `onRightIconClick` prop in `Input` to enable interactive icons (like clear buttons) while maintaining accessibility via `rightIconAriaLabel`.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -32,6 +32,11 @@ export function SearchBar() {
 	const searchRef = useRef<HTMLDivElement>(null)
 	const inputRef = useRef<HTMLInputElement>(null)
 	const navigate = useNavigate()
+
+	const handleClear = () => {
+		setQuery('')
+		inputRef.current?.focus()
+	}
 
 	// Debounced search
 	useEffect(() => {
@@ -176,7 +181,17 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	let rightIcon
+	let onRightIconClick
+	let rightIconAriaLabel
+
+	if (isLoading) {
+		rightIcon = <Spinner size="sm" variant="secondary" />
+	} else if (query) {
+		rightIcon = <CloseIcon className="w-4 h-4" />
+		onRightIconClick = handleClear
+		rightIconAriaLabel = 'Clear search'
+	}
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +204,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				onRightIconClick={onRightIconClick}
+				rightIconAriaLabel={rightIconAriaLabel}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,16 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Callback function when the right icon is clicked.
+	 * Makes the right icon interactive.
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * Accessibility label for the right icon button.
+	 * Required if onRightIconClick is provided.
+	 */
+	rightIconAriaLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +65,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconAriaLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -153,14 +165,29 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 						{...props}
 					/>
 					{rightIcon && (
-						<div
-							className={cn(
-								'absolute right-3 top-1/2 -translate-y-1/2',
-								'text-text-disabled',
-								'pointer-events-none',
-								error && 'text-error-500 dark:text-error-400'
-							)}>
-							{rightIcon}
+						<div className="absolute right-3 top-1/2 -translate-y-1/2">
+							{onRightIconClick ? (
+								<button
+									type="button"
+									onClick={onRightIconClick}
+									aria-label={rightIconAriaLabel}
+									className={cn(
+										'text-text-disabled hover:text-text-primary transition-colors',
+										'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 rounded-sm',
+										error && 'text-error-500 dark:text-error-400'
+									)}>
+									{rightIcon}
+								</button>
+							) : (
+								<div
+									className={cn(
+										'text-text-disabled',
+										'pointer-events-none',
+										error && 'text-error-500 dark:text-error-400'
+									)}>
+									{rightIcon}
+								</div>
+							)}
 						</div>
 					)}
 				</div>

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,22 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should render interactive right icon when onRightIconClick is provided', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleClick}
+				rightIconAriaLabel="Clear"
+			/>
+		)
+
+		const button = screen.getByRole('button', { name: 'Clear' })
+		expect(button).toBeInTheDocument()
+
+		fireEvent.click(button)
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
 })


### PR DESCRIPTION
* 💡 What: Added a clear (X) button to the SearchBar when text is entered.
* 🎯 Why: To allow users to quickly clear their search query without manually deleting text.
* ♿ Accessibility: The clear button is keyboard accessible (tabbable) and has an `aria-label="Clear search"`.
* 📸 Implementation: Enhanced `Input` component to support interactive right icons via `onRightIconClick`.

---
*PR created automatically by Jules for task [1320287671579288518](https://jules.google.com/task/1320287671579288518) started by @burnoutberni*