### PR TITLE
Add clear button to SearchBar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2024-05-22 - Interactive Input Icons
+**Learning:** The `Input` component pattern with `rightIcon` was non-interactive (`pointer-events-none`). Extending it with `onRightIconClick` enables accessible interaction patterns (like clear buttons) while maintaining visual consistency.
+**Action:** When needing interactive icons in inputs, use the `onRightIconClick` prop instead of wrapping the Input or creating custom overlays, to ensure proper keyboard accessibility and focus management.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import React, { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -174,9 +174,20 @@ export function SearchBar() {
 
 	const selectableItems = getSelectableItems()
 
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	let rightIcon: React.ReactNode
+	if (isLoading) {
+		rightIcon = <Spinner size="sm" variant="secondary" />
+	} else if (query) {
+		rightIcon = <CloseIcon className="w-5 h-5" />
+	}
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +200,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				onRightIconClick={query && !isLoading ? handleClear : undefined}
+				rightIconAriaLabel={query && !isLoading ? 'Clear search' : undefined}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,15 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Callback when right icon is clicked.
+	 * If provided, the right icon becomes interactive.
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * Aria label for the right icon button when it is interactive
+	 */
+	rightIconAriaLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +64,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconAriaLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -157,9 +168,21 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								onRightIconClick
+									? 'cursor-pointer pointer-events-auto hover:text-text-primary'
+									: 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
-							)}>
+							)}
+							onClick={onRightIconClick}
+							role={onRightIconClick ? 'button' : undefined}
+							aria-label={rightIconAriaLabel}
+							tabIndex={onRightIconClick ? 0 : undefined}
+							onKeyDown={(e) => {
+								if (onRightIconClick && (e.key === 'Enter' || e.key === ' ')) {
+									e.preventDefault()
+									onRightIconClick()
+								}
+							}}>
 							{rightIcon}
 						</div>
 					)}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,42 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should call onRightIconClick when right icon is clicked', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleClick}
+				rightIconAriaLabel="Clear"
+			/>
+		)
+
+		const button = screen.getByRole('button', { name: 'Clear' })
+		fireEvent.click(button)
+
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
+
+	it('should support keyboard interaction on right icon', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleClick}
+				rightIconAriaLabel="Clear"
+			/>
+		)
+
+		const button = screen.getByRole('button', { name: 'Clear' })
+		button.focus()
+		fireEvent.keyDown(button, { key: 'Enter' })
+
+		expect(handleClick).toHaveBeenCalledTimes(1)
+
+		fireEvent.keyDown(button, { key: ' ' })
+		expect(handleClick).toHaveBeenCalledTimes(2)
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { SearchBar } from '../../components/SearchBar'
+import { api } from '@/lib/api-client'
+
+// Mock API
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+// Mock Theme Colors
+vi.mock('@/design-system', () => ({
+	useThemeColors: () => ({
+		info: { 500: '#3b82f6' },
+	}),
+}))
+
+describe('SearchBar', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('should render search input', () => {
+		render(
+			<MemoryRouter>
+				<SearchBar />
+			</MemoryRouter>
+		)
+		expect(
+			screen.getByPlaceholderText('Search events, users, or @user@domain...')
+		).toBeInTheDocument()
+	})
+
+	it('should show clear button when typing', async () => {
+		const mockGet = vi.mocked(api.get)
+		mockGet.mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+		render(
+			<MemoryRouter>
+				<SearchBar />
+			</MemoryRouter>
+		)
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Advance debounce timer and allow promise resolution
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+
+		expect(mockGet).toHaveBeenCalled()
+
+		// The clear button should be present now
+		expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument()
+	})
+
+	it('should clear input and focus when clear button is clicked', async () => {
+		const mockGet = vi.mocked(api.get)
+		mockGet.mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+		render(
+			<MemoryRouter>
+				<SearchBar />
+			</MemoryRouter>
+		)
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Advance debounce timer
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+
+		const clearButton = screen.getByRole('button', { name: 'Clear search' })
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+		expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument()
+	})
+
+	it('should show loading spinner when searching', async () => {
+		const mockGet = vi.mocked(api.get)
+		mockGet.mockReturnValue(new Promise(() => {})) // Never resolves
+
+		render(
+			<MemoryRouter>
+				<SearchBar />
+			</MemoryRouter>
+		)
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Advance timers to trigger effect
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+
+		expect(mockGet).toHaveBeenCalled()
+
+		// Spinner should be visible (Clear button hidden)
+		expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION
Implemented a clear button for the `SearchBar` component to improve user experience. This required enhancing the generic `Input` component to support interactive icons on the right side, which was done in an accessible way (keyboard support, ARIA labels). verified with unit tests and visual verification.

---
*PR created automatically by Jules for task [17253847158802740453](https://jules.google.com/task/17253847158802740453) started by @burnoutberni*