### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize incoming ActivityPub content to prevent Stored XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-31 - Stored XSS in Federation Handlers
+**Vulnerability:** Incoming ActivityPub content (Events, Notes, Profiles) was stored directly in the database without sanitization.
+**Learning:** The codebase assumed frontend sanitization (via `SafeHTML`) was sufficient, violating defense-in-depth principles. Backend services must sanitize untrusted input from federation.
+**Prevention:** Added `sanitizeHtml` and `sanitizeText` using `isomorphic-dompurify` in `src/federation.ts` before database storage.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -11,6 +11,7 @@ import {
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
 import { safeFetch } from './lib/ssrfProtection.js'
+import { sanitizeText, sanitizeHtml } from './lib/sanitization.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
@@ -507,12 +508,18 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
 	const getNumber = (val: unknown) => (typeof val === 'number' ? val : null)
 
+	// Sanitize text fields
+	const rawName = getString(eventObj.name)
+	const rawSummary = getString(eventObj.summary)
+	const rawContent = getString(eventObj.content)
+	const rawLocation = getLocationValue(eventObj.location)
+
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: rawName ? sanitizeText(rawName) : '',
+		eventSummary: rawSummary ? sanitizeHtml(rawSummary) : null,
+		eventContent: rawContent ? sanitizeHtml(rawContent) : null,
+		locationValue: rawLocation ? sanitizeText(rawLocation) : null,
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -786,7 +793,8 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const rawContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = rawContent ? sanitizeHtml(rawContent) : ''
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,8 +901,8 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const rawName = typeof eventObj.name === 'string' ? eventObj.name : ''
+	const rawSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
@@ -913,12 +921,17 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 		locationValue = null
 	}
 
+	// Sanitize updated fields
+	const eventName = rawName ? sanitizeText(rawName) : ''
+	const eventSummary = rawSummary ? sanitizeHtml(rawSummary) : null
+	const sanitizedLocation = locationValue ? sanitizeText(locationValue) : null
+
 	await prisma.event.updateMany({
 		where: { externalId: eventId },
 		data: {
 			title: eventName,
 			summary: eventSummary || null,
-			location: locationValue,
+			location: sanitizedLocation,
 			startTime: new Date(eventStartTime),
 			endTime: eventEndTime ? new Date(eventEndTime) : null,
 			eventStatus: eventStatus as string | null,
@@ -945,8 +958,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeHtml(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -5,6 +5,40 @@
 
 import DOMPurify from 'isomorphic-dompurify'
 
+// Configuration for safe HTML sanitization
+// Matches the frontend's SafeHTML component configuration
+const HTML_CONFIG = {
+	ALLOWED_TAGS: [
+		'p',
+		'br',
+		'strong',
+		'b',
+		'em',
+		'i',
+		'u',
+		's',
+		'strike',
+		'del',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'ul',
+		'ol',
+		'li',
+		'a',
+		'blockquote',
+		'pre',
+		'code',
+		'span',
+		'div',
+	],
+	ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+	ALLOWED_URI_REGEXP: /^(https?:|mailto:|tel:|\/)/i,
+}
+
 /**
  * Sanitizes plain text (strips all HTML)
  * @param input - Raw text that may contain HTML
@@ -15,4 +49,13 @@ export function sanitizeText(input: string): string {
 		ALLOWED_TAGS: [],
 		ALLOWED_ATTR: [],
 	})
+}
+
+/**
+ * Sanitizes HTML content, allowing only safe tags and attributes
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML safe for storage/rendering
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, HTML_CONFIG)
 }

--- a/src/tests/federation.sanitization.test.ts
+++ b/src/tests/federation.sanitization.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for Federation Sanitization
+ * Verifies that incoming activities are properly sanitized to prevent XSS
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { config } from 'dotenv'
+config()
+import { handleActivity } from '../federation.js'
+import { ActivityType, ObjectType } from '../constants/activitypub.js'
+import { prisma } from '../lib/prisma.js'
+import * as activitypubHelpers from '../lib/activitypubHelpers.js'
+import * as realtime from '../realtime.js'
+
+// Mock dependencies
+vi.mock('../lib/activitypubHelpers.js')
+vi.mock('../services/ActivityBuilder.js')
+vi.mock('../services/ActivityDelivery.js')
+vi.mock('../realtime.js')
+
+describe('Federation Sanitization', () => {
+	const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+
+	beforeEach(async () => {
+		// Clean up
+		await prisma.processedActivity.deleteMany({})
+		await prisma.event.deleteMany({})
+		await prisma.comment.deleteMany({})
+		await prisma.user.deleteMany({})
+
+		// Reset mocks
+		vi.clearAllMocks()
+	})
+
+	it('should sanitize Event title and summary on Create', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/hacker',
+			type: 'Person',
+			preferredUsername: 'hacker',
+			inbox: 'https://example.com/users/hacker/inbox',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'hacker@example.com',
+				email: 'hacker@example.com',
+				name: 'Hacker',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+				inboxUrl: remoteActor.inbox,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+		vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+		const activity = {
+			id: 'https://example.com/activities/create-xss',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/xss-event',
+				name: 'Safe Title <script>alert(1)</script>',
+				summary: '<p>Safe Summary <script>alert(1)</script></p>',
+				location: 'Safe Location <img src=x onerror=alert(1)>',
+				startTime: new Date().toISOString(),
+				endTime: new Date(Date.now() + 3600000).toISOString(),
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const event = await prisma.event.findFirst({
+			where: { externalId: activity.object.id },
+		})
+
+		expect(event).toBeTruthy()
+		// Title should strip ALL HTML
+		expect(event?.title).toBe('Safe Title ')
+		// Summary should allow safe HTML but strip script
+		expect(event?.summary).toBe('<p>Safe Summary </p>')
+		// Location should strip ALL HTML
+		expect(event?.location).toBe('Safe Location ')
+	})
+
+	it('should sanitize Note content on Create', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/hacker',
+			type: 'Person',
+			preferredUsername: 'hacker',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'hacker@example.com',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+			},
+		})
+
+		// Create a target event
+		const targetEvent = await prisma.event.create({
+			data: {
+				title: 'Target Event',
+				startTime: new Date(),
+				externalId: 'https://example.com/events/target',
+				attributedTo: 'https://example.com/users/victim',
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+		const activity = {
+			id: 'https://example.com/activities/create-note-xss',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.NOTE,
+				id: 'https://example.com/comments/xss',
+				content: '<p>Click me <a href="javascript:alert(1)">here</a></p>',
+				inReplyTo: targetEvent.externalId,
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const comment = await prisma.comment.findFirst({
+			where: { externalId: activity.object.id },
+		})
+
+		expect(comment).toBeTruthy()
+		// Content should strip javascript: link
+		expect(comment?.content).toBe('<p>Click me <a>here</a></p>')
+	})
+
+	it('should sanitize Event updates', async () => {
+		const remoteEvent = await prisma.event.create({
+			data: {
+				title: 'Original Title',
+				startTime: new Date(),
+				externalId: 'https://example.com/events/update-xss',
+				attributedTo: 'https://example.com/users/hacker',
+			},
+		})
+
+		const activity = {
+			id: 'https://example.com/activities/update-event-xss',
+			type: ActivityType.UPDATE,
+			actor: 'https://example.com/users/hacker',
+			object: {
+				type: ObjectType.EVENT,
+				id: remoteEvent.externalId,
+				name: 'Updated Title <script>alert(1)</script>',
+				summary: '<p>Updated Summary <iframe src="javascript:alert(1)"></iframe></p>',
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const updatedEvent = await prisma.event.findUnique({
+			where: { id: remoteEvent.id },
+		})
+
+		expect(updatedEvent?.title).toBe('Updated Title ')
+		expect(updatedEvent?.summary).toBe('<p>Updated Summary </p>')
+	})
+
+	it('should sanitize Profile updates', async () => {
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'hacker@example.com',
+				isRemote: true,
+				externalActorUrl: 'https://example.com/users/hacker',
+				name: 'Original Name',
+			},
+		})
+
+		const activity = {
+			id: 'https://example.com/activities/update-profile-xss',
+			type: ActivityType.UPDATE,
+			actor: 'https://example.com/users/hacker',
+			object: {
+				type: ObjectType.PERSON,
+				id: 'https://example.com/users/hacker',
+				name: 'Hacker <script>alert(1)</script>',
+				summary: '<b>Hacker Bio</b> <img src=x onerror=alert(1)>',
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const updatedUser = await prisma.user.findUnique({
+			where: { id: remoteUser.id },
+		})
+
+		expect(updatedUser?.name).toBe('Hacker ')
+		expect(updatedUser?.bio).toBe('<b>Hacker Bio</b> ')
+	})
+})

--- a/src/tests/sanitization.test.ts
+++ b/src/tests/sanitization.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeText, sanitizeHtml } from '../lib/sanitization.js'
+
+describe('Sanitization Utils', () => {
+	describe('sanitizeText', () => {
+		it('should remove all HTML tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeText(input)).toBe('Hello World')
+		})
+
+		it('should handle nested tags', () => {
+			const input = '<div><p>Test</p></div>'
+			expect(sanitizeText(input)).toBe('Test')
+		})
+
+		it('should remove script tags and content', () => {
+			// DOMPurify default behavior for script tags is to remove the tag but keep content if not configured otherwise?
+			// Wait, sanitizeText uses empty allowed tags.
+			// Let's verify behavior. DOMPurify.sanitize with empty allowed tags usually keeps text content.
+			// But script content is usually removed by DOMPurify.
+			const input = '<script>alert(1)</script>Hello'
+			expect(sanitizeText(input)).toBe('Hello')
+		})
+	})
+
+	describe('sanitizeHtml', () => {
+		it('should allow safe tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello <b>World</b></p>')
+		})
+
+		it('should remove unsafe tags', () => {
+			const input = '<p>Hello <script>alert(1)</script>World</p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello World</p>')
+		})
+
+		it('should allow safe attributes', () => {
+			const input = '<a href="https://example.com" title="Example">Link</a>'
+			expect(sanitizeHtml(input)).toBe('<a href="https://example.com" title="Example">Link</a>')
+		})
+
+		it('should remove unsafe attributes', () => {
+			const input = '<div onclick="alert(1)">Hello</div>'
+			expect(sanitizeHtml(input)).toBe('<div>Hello</div>')
+		})
+
+		it('should remove javascript: links', () => {
+			const input = '<a href="javascript:alert(1)">Click me</a>'
+			// DOMPurify removes the href attribute if it contains javascript:
+			expect(sanitizeHtml(input)).toBe('<a>Click me</a>')
+		})
+	})
+})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS in Federation Handlers. Incoming ActivityPub content (Events, Notes, Profiles) was stored directly in the database without sanitization.
🎯 Impact: Malicious actors could inject scripts via federated activities (Create/Update Event, Note, Person), potentially compromising other users or instances consuming this data.
🔧 Fix:
- Enhanced `src/lib/sanitization.ts` to include `sanitizeHtml` using `isomorphic-dompurify` with a safe whitelist (matching frontend config).
- Updated `src/federation.ts` to sanitize:
    - Event names and locations with `sanitizeText`.
    - Event summaries/content with `sanitizeHtml`.
    - Note content with `sanitizeHtml`.
    - User names with `sanitizeText` and bios with `sanitizeHtml`.
✅ Verification: Added `src/tests/federation.sanitization.test.ts` to verify XSS vectors are stripped. Ran existing tests.

---
*PR created automatically by Jules for task [6792755724059400070](https://jules.google.com/task/6792755724059400070) started by @burnoutberni*