### PR TITLE
🎨 Palette: Fix AppealModal accessibility by using label props

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Inconsistent Form Labeling Patterns
+**Learning:** Some modals (like `AppealModal`) were manually rendering `<label>` elements separate from inputs, while `Input`/`Select`/`Textarea` components support a `label` prop that handles ID generation and `htmlFor` association automatically. The manual approach often leads to missing `htmlFor` attributes, breaking accessibility.
+**Action:** Always check if UI components support a `label` prop before manually creating one. Refactor manual labels to use the component prop for guaranteed accessibility linkage.

--- a/client/src/components/AppealModal.tsx
+++ b/client/src/components/AppealModal.tsx
@@ -70,8 +70,10 @@ export function AppealModal({
 		<Modal isOpen={isOpen} onClose={onClose} title="Submit Appeal">
 			<form onSubmit={handleSubmit} className="space-y-4">
 				<div className="space-y-2">
-					<label className="text-sm font-medium text-text-primary">Appeal Type</label>
-					<Select value={type} onChange={(e) => setType(e.target.value as AppealType)}>
+					<Select
+						label="Appeal Type"
+						value={type}
+						onChange={(e) => setType(e.target.value as AppealType)}>
 						{Object.entries(APPEAL_TYPE_LABELS).map(([value, label]) => (
 							<option key={value} value={value}>
 								{label}
@@ -81,8 +83,8 @@ export function AppealModal({
 				</div>
 
 				<div className="space-y-2">
-					<label className="text-sm font-medium text-text-primary">Reason</label>
 					<Textarea
+						label="Reason"
 						value={reason}
 						onChange={(e) => setReason(e.target.value)}
 						placeholder="Please explain why this decision should be reversed..."

--- a/client/src/tests/components/AppealModal.test.tsx
+++ b/client/src/tests/components/AppealModal.test.tsx
@@ -109,9 +109,7 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })
@@ -133,9 +131,7 @@ describe('AppealModal Component', () => {
 			{ wrapper }
 		)
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })
@@ -164,9 +160,7 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })
@@ -207,9 +201,7 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		) as HTMLTextAreaElement
+		const textarea = screen.getByLabelText(/Reason/i) as HTMLTextAreaElement
 		await user.type(textarea, 'This is my appeal reason')
 
 		// Verify textarea has content before submission
@@ -242,8 +234,8 @@ describe('AppealModal Component', () => {
 
 		// If modal is still open (shouldn't be), verify textarea is empty
 		// Otherwise, the fact that onClose was called confirms the form was reset before closing
-		const updatedTextarea = screen.queryByPlaceholderText(
-			/Please explain why this decision should be reversed/i
+		const updatedTextarea = screen.queryByLabelText(
+			/Reason/i
 		) as HTMLTextAreaElement | null
 		if (updatedTextarea) {
 			expect(updatedTextarea.value).toBe('')
@@ -259,9 +251,7 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })
@@ -289,15 +279,12 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		// Find select by finding the element that contains the "Content Removal" option
-		const contentRemovalOption = screen.getByText('Content Removal')
-		const select = contentRemovalOption.closest('select') as HTMLSelectElement
+		// Find select by accessible label
+		const select = screen.getByLabelText(/Appeal Type/i) as HTMLSelectElement
 		expect(select).toBeInTheDocument()
 		await user.selectOptions(select, 'ACCOUNT_SUSPENSION')
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })
@@ -323,9 +310,7 @@ describe('AppealModal Component', () => {
 			wrapper,
 		})
 
-		const textarea = screen.getByPlaceholderText(
-			/Please explain why this decision should be reversed/i
-		)
+		const textarea = screen.getByLabelText(/Reason/i)
 		await user.type(textarea, 'This is my appeal reason')
 
 		const submitButton = screen.getByRole('button', { name: /Submit Appeal/i })


### PR DESCRIPTION
🎨 **Accessibility Improvement**

In `AppealModal.tsx`, the `Select` and `Textarea` components were being used with manually rendered `<label>` elements. This often leads to accessibility issues where the label is not programmatically associated with the input (missing `htmlFor`/`id`).

**Changes:**
- Refactored `AppealModal.tsx` to pass the `label` prop directly to `Select` and `Textarea` components.
- These components automatically handle ID generation and `htmlFor` association, ensuring a robust accessible experience.
- Verified that the "Reason" field now correctly shows the required indicator (`*`) which is handled by the component logic.

**Verification:**
- `client/src/tests/components/AppealModal.test.tsx` passed.
- Visual verification using Playwright confirmed the modal renders correctly with labels.


---
*PR created automatically by Jules for task [1239345813373199133](https://jules.google.com/task/1239345813373199133) started by @burnoutberni*