### PR TITLE
🛡️ Sentinel: [HIGH] Prevent Stored XSS in Federation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-01 - ActivityPub Ingress Sanitization Gap
+**Vulnerability:** Incoming ActivityPub data (events, comments, profiles) was stored raw in the database, creating a Stored XSS risk if consumed by clients without strict output sanitization (defense-in-depth gap).
+**Learning:** The application relied solely on frontend `SafeHTML` for sanitization. While effective for the web client, this leaves the database tainted and risks other clients (mobile, API consumers) rendering malicious content.
+**Prevention:** Always sanitize user input at the ingress point (Federation handlers) before storage, using a shared configuration with the frontend to ensure consistency.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -11,6 +11,7 @@ import {
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
 import { safeFetch } from './lib/ssrfProtection.js'
+import { sanitizeText, sanitizeHtml } from './lib/sanitization.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
@@ -501,7 +502,7 @@ function getAttachmentUrl(attachment: unknown): string | null {
 	return null
 }
 
-function extractEventProperties(event: ActivityPubEvent | Record<string, unknown>) {
+export function extractEventProperties(event: ActivityPubEvent | Record<string, unknown>) {
 	const eventObj = event as Record<string, unknown>
 
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
@@ -509,10 +510,10 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: sanitizeText(getString(eventObj.name) || ''),
+		eventSummary: sanitizeHtml(getString(eventObj.summary) || ''),
+		eventContent: sanitizeHtml(getString(eventObj.content) || ''),
+		locationValue: sanitizeText(getLocationValue(eventObj.location) || ''),
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -521,7 +522,7 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 		eventAttendanceMode: eventObj.eventAttendanceMode,
 		eventMaxCapacity: getNumber(eventObj.maximumAttendeeCapacity),
 		attachmentUrl: getAttachmentUrl(eventObj.attachment),
-		attributedTo: getString(eventObj.attributedTo),
+		attributedTo: sanitizeText(getString(eventObj.attributedTo) || ''),
 	}
 }
 
@@ -786,7 +787,7 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = typeof noteObj.content === 'string' ? sanitizeHtml(noteObj.content) : ''
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,22 +894,23 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const eventName = typeof eventObj.name === 'string' ? sanitizeText(eventObj.name) : ''
+	const eventSummary =
+		typeof eventObj.summary === 'string' ? sanitizeHtml(eventObj.summary) : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
 	const eventLocation = eventObj.location
 	let locationValue: string | null
 	if (typeof eventLocation === 'string') {
-		locationValue = eventLocation
+		locationValue = sanitizeText(eventLocation)
 	} else if (
 		eventLocation &&
 		isNonNullObject(eventLocation) &&
 		'name' in eventLocation &&
 		typeof eventLocation.name === 'string'
 	) {
-		locationValue = eventLocation.name
+		locationValue = sanitizeText(eventLocation.name)
 	} else {
 		locationValue = null
 	}
@@ -945,8 +947,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeHtml(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -5,6 +5,56 @@
 
 import DOMPurify from 'isomorphic-dompurify'
 
+// Regular expression to match external URLs (http://, https://, or protocol-relative //)
+const EXTERNAL_URL_REGEX = /^(https?:\/\/|\/\/)/i
+
+// Hook function to add security attributes to external links
+// This ensures that links in sanitized content are safe
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+	// Check if node is an Element (has tagName and getAttribute)
+	if ('tagName' in node && node.tagName === 'A' && 'getAttribute' in node) {
+		const href = node.getAttribute('href')
+		if (href && EXTERNAL_URL_REGEX.test(href)) {
+			node.setAttribute('target', '_blank')
+			node.setAttribute('rel', 'noopener noreferrer')
+		}
+	}
+})
+
+// DOMPurify configuration for safe HTML sanitization
+// Matches the frontend configuration in client/src/components/ui/SafeHTML.tsx
+const DOMPURIFY_CONFIG = {
+	ALLOWED_TAGS: [
+		'p',
+		'br',
+		'strong',
+		'b',
+		'em',
+		'i',
+		'u',
+		's',
+		'strike',
+		'del',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'ul',
+		'ol',
+		'li',
+		'a',
+		'blockquote',
+		'pre',
+		'code',
+		'span',
+		'div',
+	],
+	ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+	ALLOWED_URI_REGEXP: /^(https?:|mailto:|tel:|\/)/i,
+}
+
 /**
  * Sanitizes plain text (strips all HTML)
  * @param input - Raw text that may contain HTML
@@ -15,4 +65,13 @@ export function sanitizeText(input: string): string {
 		ALLOWED_TAGS: [],
 		ALLOWED_ATTR: [],
 	})
+}
+
+/**
+ * Sanitizes HTML content while preserving safe tags and attributes
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML with dangerous tags/attributes removed
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, DOMPURIFY_CONFIG)
 }

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -8,9 +8,20 @@ import DOMPurify from 'isomorphic-dompurify'
 // Regular expression to match external URLs (http://, https://, or protocol-relative //)
 const EXTERNAL_URL_REGEX = /^(https?:\/\/|\/\/)/i
 
+// Define a minimal interface for the DOM node since we don't have global DOM types
+interface SanitizationNode {
+	tagName: string
+	getAttribute(name: string): string | null
+	setAttribute(name: string, value: string): void
+}
+
 // Hook function to add security attributes to external links
 // This ensures that links in sanitized content are safe
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+DOMPurify.addHook('afterSanitizeAttributes', (currentNode) => {
+	// Cast to unknown first then to our interface to satisfy TypeScript
+	// We rely on runtime checks to ensure safety
+	const node = currentNode as unknown as SanitizationNode
+
 	// Check if node is an Element (has tagName and getAttribute)
 	if ('tagName' in node && node.tagName === 'A' && 'getAttribute' in node) {
 		const href = node.getAttribute('href')

--- a/src/tests/federation.sanitization.test.ts
+++ b/src/tests/federation.sanitization.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { extractEventProperties } from '../federation.js'
+
+describe('Federation Sanitization', () => {
+	describe('extractEventProperties', () => {
+		it('sanitizes event name', () => {
+			const event = {
+				id: '1',
+				name: '<script>alert(1)</script>Event Name',
+				startTime: '2023-01-01T12:00:00Z',
+			}
+			const result = extractEventProperties(event)
+			expect(result.eventName).toBe('Event Name')
+		})
+
+		it('sanitizes event summary with allowed tags', () => {
+			const event = {
+				id: '1',
+				name: 'Event',
+				summary: '<p>Summary with <b>bold</b> text</p><script>alert(1)</script>',
+				startTime: '2023-01-01T12:00:00Z',
+			}
+			const result = extractEventProperties(event)
+			expect(result.eventSummary).toBe('<p>Summary with <b>bold</b> text</p>')
+		})
+
+		it('sanitizes event content', () => {
+			const event = {
+				id: '1',
+				name: 'Event',
+				content: '<a href="javascript:alert(1)">Dangerous Link</a>',
+				startTime: '2023-01-01T12:00:00Z',
+			}
+			const result = extractEventProperties(event)
+			expect(result.eventContent).toBe('<a>Dangerous Link</a>')
+		})
+
+		it('sanitizes attributedTo', () => {
+			const event = {
+				id: '1',
+				name: 'Event',
+				attributedTo: '<script>alert(1)</script>User',
+				startTime: '2023-01-01T12:00:00Z',
+			}
+			const result = extractEventProperties(event)
+			expect(result.attributedTo).toBe('User')
+		})
+	})
+})

--- a/src/tests/sanitization.test.ts
+++ b/src/tests/sanitization.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeHtml, sanitizeText } from '../lib/sanitization.js'
+
+describe('Sanitization', () => {
+	describe('sanitizeText', () => {
+		it('removes all HTML tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeText(input)).toBe('Hello World')
+		})
+
+		it('removes scripts', () => {
+			const input = '<script>alert(1)</script>Hello'
+			expect(sanitizeText(input)).toBe('Hello')
+		})
+
+		it('handles plain text', () => {
+			const input = 'Hello World'
+			expect(sanitizeText(input)).toBe('Hello World')
+		})
+	})
+
+	describe('sanitizeHtml', () => {
+		it('preserves safe tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello <b>World</b></p>')
+		})
+
+		it('removes scripts', () => {
+			const input = '<script>alert(1)</script><p>Hello</p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello</p>')
+		})
+
+		it('removes dangerous attributes', () => {
+			const input = '<p onclick="alert(1)">Hello</p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello</p>')
+		})
+
+		it('removes iframes', () => {
+			const input = '<iframe src="javascript:alert(1)"></iframe><p>Hello</p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello</p>')
+		})
+
+		it('adds rel/target to external links', () => {
+			const input = '<a href="https://example.com">Link</a>'
+			const output = sanitizeHtml(input)
+			expect(output).toContain('target="_blank"')
+			expect(output).toContain('rel="noopener noreferrer"')
+		})
+
+		it('does not add rel/target to internal links', () => {
+			const input = '<a href="/internal">Link</a>'
+			const output = sanitizeHtml(input)
+			expect(output).not.toContain('target="_blank"')
+		})
+	})
+})


### PR DESCRIPTION
**Vulnerability:** Incoming ActivityPub data (events, comments, profiles) was previously stored raw in the database. This relied solely on frontend sanitization (`SafeHTML`), leaving the database tainted and exposing other potential consumers (mobile apps, API clients) to Stored XSS attacks.

**Fix:**
1.  Enhanced `src/lib/sanitization.ts` with a `sanitizeHtml` function that:
    *   Uses `isomorphic-dompurify`.
    *   Enforces a strict tag allowlist (matching the frontend's `SafeHTML`).
    *   Automatically adds `target="_blank" rel="noopener noreferrer"` to external links.
2.  Updated `src/federation.ts` to sanitize inputs before storage:
    *   `sanitizeText` for plain text fields (names, locations).
    *   `sanitizeHtml` for rich text fields (summaries, content, bios).
3.  Added unit tests verifying that dangerous tags (scripts, iframes) are stripped while safe formatting is preserved.

**Verification:**
Run `npx vitest run src/tests/sanitization.test.ts src/tests/federation.sanitization.test.ts` to confirm security controls.
Run `npx vitest run src/tests/federation.test.ts` to confirm no regressions in federation logic.

---
*PR created automatically by Jules for task [14104863622364902882](https://jules.google.com/task/14104863622364902882) started by @burnoutberni*