### PR TITLE
🛡️ Sentinel: Fix Stored XSS in ActivityPub Federation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-02 - Stored XSS in ActivityPub Federation
+**Vulnerability:** User-generated content from external ActivityPub instances (event summaries, comments, profile bios) was being stored in the database without sanitization and subsequently rendered by clients.
+**Learning:** Federation handlers often trust the "structure" of the data (JSON schemas) but forget that the *content* strings (HTML/Markdown) within that structure are untrusted user input. The assumption that "backend only processes data" is dangerous when that data is rich text intended for display.
+**Prevention:** All ingress points for user-generated content, especially from federation/external sources, must pass through strict HTML sanitization (e.g., `DOMPurify`) before being persisted. We also enforced `target="_blank"` on links to prevent reverse tabnabbing.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -17,6 +17,7 @@ import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
 import { prisma } from './lib/prisma.js'
 import { trackInstance } from './lib/instanceHelpers.js'
 import { logger } from './lib/logger.js'
+import { sanitizeText, sanitizeHtml } from './lib/sanitization.js'
 import type { Prisma, Event, User } from '@prisma/client'
 import type {
 	Activity,
@@ -507,12 +508,18 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
 	const getNumber = (val: unknown) => (typeof val === 'number' ? val : null)
 
+	const rawName = getString(eventObj.name)
+	const rawSummary = getString(eventObj.summary)
+	const rawContent = getString(eventObj.content)
+	const rawLocation = getLocationValue(eventObj.location)
+	const rawAttributedTo = getString(eventObj.attributedTo)
+
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: rawName ? sanitizeText(rawName) : '',
+		eventSummary: rawSummary ? sanitizeHtml(rawSummary) : null,
+		eventContent: rawContent ? sanitizeHtml(rawContent) : null,
+		locationValue: rawLocation ? sanitizeText(rawLocation) : null,
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -521,7 +528,7 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 		eventAttendanceMode: eventObj.eventAttendanceMode,
 		eventMaxCapacity: getNumber(eventObj.maximumAttendeeCapacity),
 		attachmentUrl: getAttachmentUrl(eventObj.attachment),
-		attributedTo: getString(eventObj.attributedTo),
+		attributedTo: rawAttributedTo ? sanitizeText(rawAttributedTo) : null,
 	}
 }
 
@@ -786,7 +793,8 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const rawContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = sanitizeHtml(rawContent)
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,22 +901,23 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const eventName = typeof eventObj.name === 'string' ? sanitizeText(eventObj.name) : ''
+	const eventSummary =
+		typeof eventObj.summary === 'string' ? sanitizeHtml(eventObj.summary) : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
 	const eventLocation = eventObj.location
 	let locationValue: string | null
 	if (typeof eventLocation === 'string') {
-		locationValue = eventLocation
+		locationValue = sanitizeText(eventLocation)
 	} else if (
 		eventLocation &&
 		isNonNullObject(eventLocation) &&
 		'name' in eventLocation &&
 		typeof eventLocation.name === 'string'
 	) {
-		locationValue = eventLocation.name
+		locationValue = sanitizeText(eventLocation.name)
 	} else {
 		locationValue = null
 	}
@@ -945,8 +954,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeHtml(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -5,6 +5,17 @@
 
 import DOMPurify from 'isomorphic-dompurify'
 
+// Add hook to enforce target="_blank" and rel="noopener noreferrer" on all links
+// This prevents reverse tabnabbing and ensures external links open in new tabs
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+	if ('target' in node) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		;(node as any).setAttribute('target', '_blank')
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		;(node as any).setAttribute('rel', 'noopener noreferrer')
+	}
+})
+
 /**
  * Sanitizes plain text (strips all HTML)
  * @param input - Raw text that may contain HTML
@@ -14,5 +25,39 @@ export function sanitizeText(input: string): string {
 	return DOMPurify.sanitize(input, {
 		ALLOWED_TAGS: [],
 		ALLOWED_ATTR: [],
+	})
+}
+
+/**
+ * Sanitizes HTML content, allowing safe tags and enforcing security attributes on links
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML safe for rendering
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, {
+		ALLOWED_TAGS: [
+			'p',
+			'br',
+			'span',
+			'a',
+			'b',
+			'i',
+			'strong',
+			'em',
+			'ul',
+			'ol',
+			'li',
+			'blockquote',
+			'code',
+			'pre',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'img',
+		],
+		ALLOWED_ATTR: ['href', 'title', 'src', 'alt', 'class', 'rel', 'target'],
 	})
 }

--- a/src/tests/lib/sanitization.test.ts
+++ b/src/tests/lib/sanitization.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeText, sanitizeHtml } from '../../lib/sanitization.js'
+
+describe('Sanitization Utils', () => {
+	describe('sanitizeText', () => {
+		it('should strip all HTML tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeText(input)).toBe('Hello World')
+		})
+
+		it('should handle nested tags', () => {
+			const input = '<div><p>Test</p></div>'
+			expect(sanitizeText(input)).toBe('Test')
+		})
+
+		it('should handle scripts', () => {
+			const input = '<script>alert("xss")</script>Test'
+			expect(sanitizeText(input)).toBe('Test')
+		})
+	})
+
+	describe('sanitizeHtml', () => {
+		it('should allow safe tags', () => {
+			const input = '<p>Hello <b>World</b></p>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello <b>World</b></p>')
+		})
+
+		it('should strip unsafe tags like script', () => {
+			const input = '<p>Hello</p><script>alert("xss")</script>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello</p>')
+		})
+
+		it('should strip unsafe tags like iframe', () => {
+			const input = '<p>Hello</p><iframe src="javascript:alert(1)"></iframe>'
+			expect(sanitizeHtml(input)).toBe('<p>Hello</p>')
+		})
+
+		it('should strip on* event handlers', () => {
+			const input = '<a href="#" onclick="alert(1)">Click me</a>'
+			// Expect sanitized output to contain the link but NOT the onclick
+			const output = sanitizeHtml(input)
+			expect(output).toContain('<a')
+			expect(output).not.toContain('onclick')
+			expect(output).toContain('Click me')
+		})
+
+		it('should add target="_blank" and rel="noopener noreferrer" to links', () => {
+			const input = '<a href="https://example.com">Example</a>'
+			const output = sanitizeHtml(input)
+			expect(output).toContain('target="_blank"')
+			expect(output).toContain('rel="noopener noreferrer"')
+			expect(output).toContain('href="https://example.com"')
+		})
+
+		it('should not add target="_blank" if already present', () => {
+			const input = '<a href="https://example.com" target="_blank">Example</a>'
+			const output = sanitizeHtml(input)
+			// It might re-order attributes, but as long as it's there and valid
+			expect(output).toContain('target="_blank"')
+			expect(output).toContain('rel="noopener noreferrer"')
+		})
+
+		it('should allow basic formatting', () => {
+			const input = '<ul><li>List 1</li><li>List 2</li></ul>'
+			expect(sanitizeHtml(input)).toBe('<ul><li>List 1</li><li>List 2</li></ul>')
+		})
+
+		it('should allow images with src', () => {
+			const input = '<img src="https://example.com/image.jpg" alt="test">'
+			const output = sanitizeHtml(input)
+			expect(output).toContain('<img')
+			expect(output).toContain('src="https://example.com/image.jpg"')
+			// alt might be preserved
+		})
+	})
+})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS via ActivityPub federation. Remote instances could inject malicious HTML scripts into event summaries, comments, and user profiles, which would be stored in the database and rendered by clients.
🎯 Impact: Attackers could execute arbitrary JavaScript in the context of other users' sessions when they view federated content, potentially stealing cookies or performing actions on their behalf.
🔧 Fix: Implemented strict HTML sanitization using `DOMPurify` at the ingress point (`src/federation.ts`). Also enforced `target="_blank"` and `rel="noopener noreferrer"` on all external links to prevent reverse tabnabbing.
✅ Verification: Added `src/tests/lib/sanitization.test.ts` to verify sanitization logic. Existing federation tests confirm no regression in functionality.

---
*PR created automatically by Jules for task [2634576389143740479](https://jules.google.com/task/2634576389143740479) started by @burnoutberni*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sanitize and persist federated rich-text content at ingestion, which is security-critical and could affect how remote event/profile/comment data renders across clients.
> 
> **Overview**
> Prevents **stored XSS from federated ActivityPub content** by sanitizing remote event fields (`name`, `summary`, `content`, `location`, `attributedTo`), note/comment `content`, and remote profile (`Person`) `name`/`summary` before writing to the database.
> 
> Adds a stricter `sanitizeHtml` utility (allowlist-based) alongside `sanitizeText`, including a DOMPurify hook to enforce `target="_blank"` and `rel="noopener noreferrer"` on links, plus new Vitest coverage for the sanitization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 757096eb85719f31f7af48c3d5e231cdf8ddabaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->