### PR TITLE
🎨 Palette: Add clear button to search bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Input Component Right Icon Interactivity
+**Learning:** The `Input` component's `rightIcon` wrapper had `pointer-events-none`, preventing interactive elements like clear buttons.
+**Action:** When adding interactive icons to inputs (like clear or toggle password), use the new `onRightIconClick` prop which renders a semantic `<button>` and handles accessibility and pointer events automatically.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,16 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		inputRef.current?.focus()
+	}
+
+	const rightElement = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<CloseIcon className="w-4 h-4" />
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +198,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightElement}
+				onRightIconClick={!isLoading && query ? handleClear : undefined}
+				rightIconAriaLabel="Clear search"
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,14 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Optional click handler for the right icon
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * Accessibility label for the right icon button
+	 */
+	rightIconAriaLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +63,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconAriaLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -152,17 +162,31 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 						aria-required={required}
 						{...props}
 					/>
-					{rightIcon && (
-						<div
-							className={cn(
-								'absolute right-3 top-1/2 -translate-y-1/2',
-								'text-text-disabled',
-								'pointer-events-none',
-								error && 'text-error-500 dark:text-error-400'
-							)}>
-							{rightIcon}
-						</div>
-					)}
+					{rightIcon &&
+						(onRightIconClick ? (
+							<button
+								type="button"
+								onClick={onRightIconClick}
+								aria-label={rightIconAriaLabel}
+								className={cn(
+									'absolute right-3 top-1/2 -translate-y-1/2',
+									'text-text-disabled hover:text-text-primary transition-colors',
+									'cursor-pointer',
+									error && 'text-error-500 dark:text-error-400'
+								)}>
+								{rightIcon}
+							</button>
+						) : (
+							<div
+								className={cn(
+									'absolute right-3 top-1/2 -translate-y-1/2',
+									'text-text-disabled',
+									'pointer-events-none',
+									error && 'text-error-500 dark:text-error-400'
+								)}>
+								{rightIcon}
+							</div>
+						))}
 				</div>
 				{error && errorMessage && (
 					<p

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,23 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should render right icon as button when onRightIconClick is provided', () => {
+		const handleRightIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>X</span>}
+				onRightIconClick={handleRightIconClick}
+				rightIconAriaLabel="Clear"
+			/>
+		)
+
+		const button = screen.getByLabelText('Clear')
+		expect(button).toBeInTheDocument()
+		expect(button.tagName).toBe('BUTTON')
+
+		fireEvent.click(button)
+		expect(handleRightIconClick).toHaveBeenCalledTimes(1)
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Mock the API client
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn().mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null }),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar', () => {
+	const { wrapper } = createTestWrapper()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+		expect(input).toBeInTheDocument()
+	})
+
+	it('should show clear button when typing', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Advance timers to trigger the api call and resolve loading state
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+
+		// Clear button should appear
+		const clearButton = screen.getByLabelText('Clear search')
+		expect(clearButton).toBeInTheDocument()
+	})
+
+	it('should clear input when clear button is clicked', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Advance timers to trigger the api call and resolve loading state
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+
+		const clearButton = screen.getByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+	})
+
+	it('should not show clear button when input is empty', () => {
+		render(<SearchBar />, { wrapper })
+		const clearButton = screen.queryByLabelText('Clear search')
+		expect(clearButton).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION
💡 What: Added a clear button ('X' icon) to the search bar that appears when text is entered.
🎯 Why: To allow users to easily clear their search query and reset the input focus.
♿ Accessibility: The clear button is a semantic <button> with aria-label="Clear search" and keyboard focus support.

---
*PR created automatically by Jules for task [16127870504829640109](https://jules.google.com/task/16127870504829640109) started by @burnoutberni*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility enhancement; main concern is any existing `rightIcon` usage now needing an aria-label when made clickable via `onRightIconClick`.
> 
> **Overview**
> Adds support for **interactive right-side icons** on the shared `Input` component via new `onRightIconClick`/`rightIconAriaLabel` props, rendering the `rightIcon` as a semantic `<button>` (instead of a non-interactive wrapper) when a handler is provided.
> 
> Updates `SearchBar` to show a right-side spinner while loading and a `CloseIcon` clear action when text is present, clearing the query and returning focus to the input. Adds focused tests covering the new `Input` behavior and the SearchBar clear button, plus a short palette note documenting the pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2684d645426dee8d7aab7837adcbe97f56d5133e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->