### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-03 - Interactive Icons in Inputs
+**Learning:** Standard input components often wrap icons in `pointer-events-none` containers for layout stability. To support interactive icons (like clear buttons), we must explicitly manage pointer events and accessibility attributes (role, tabIndex, aria-label) on the wrapper.
+**Action:** When adding interactive elements to existing inputs, ensure the wrapper allows pointer events and provides proper accessible names, handling disabled states gracefully.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import React, { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,21 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	let rightIcon: React.ReactNode
+	let onRightIconClick: (() => void) | undefined
+	let rightIconLabel: string | undefined
+
+	if (isLoading) {
+		rightIcon = <Spinner size="sm" variant="secondary" />
+	} else if (query) {
+		rightIcon = <CloseIcon className="w-4 h-4" />
+		rightIconLabel = 'Clear search'
+		onRightIconClick = () => {
+			setQuery('')
+			setIsOpen(false)
+			inputRef.current?.focus()
+		}
+	}
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +203,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				onRightIconClick={onRightIconClick}
+				rightIconLabel={rightIconLabel}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,15 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Callback when the right icon is clicked.
+	 * If provided, the right icon wrapper becomes interactive.
+	 */
+	onRightIconClick?: () => void
+	/**
+	 * ARIA label for the right icon button when interactive
+	 */
+	rightIconLabel?: string
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +64,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			onRightIconClick,
+			rightIconLabel,
 			fullWidth = false,
 			className,
 			id,
@@ -157,9 +168,24 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								(!onRightIconClick || disabled) && 'pointer-events-none',
+								onRightIconClick && !disabled && 'cursor-pointer hover:text-text-primary',
 								error && 'text-error-500 dark:text-error-400'
-							)}>
+							)}
+							onClick={!disabled ? onRightIconClick : undefined}
+							role={onRightIconClick && !disabled ? 'button' : undefined}
+							aria-label={rightIconLabel}
+							tabIndex={onRightIconClick && !disabled ? 0 : undefined}
+							onKeyDown={
+								onRightIconClick && !disabled
+									? (e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault()
+												onRightIconClick()
+											}
+										}
+									: undefined
+							}>
 							{rightIcon}
 						</div>
 					)}

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SearchBar } from '../../components/SearchBar'
 import { BrowserRouter } from 'react-router-dom'
 

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { BrowserRouter } from 'react-router-dom'
+
+// Mock dependencies
+vi.mock('@/lib/api-client', () => ({
+    api: {
+        get: vi.fn().mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null }),
+        post: vi.fn(),
+    }
+}))
+
+vi.mock('@/design-system', () => ({
+    useThemeColors: () => ({ info: { 500: '#000000' } })
+}))
+
+describe('SearchBar', () => {
+    it('should show clear button when there is text', async () => {
+        render(
+            <BrowserRouter>
+                <SearchBar />
+            </BrowserRouter>
+        )
+
+        const input = screen.getByPlaceholderText(/Search events, users/i)
+        fireEvent.change(input, { target: { value: 'test' } })
+
+        // The clear button should appear. It's the only button in the initial state (search icon is not a button)
+        const clearButton = await screen.findByRole('button')
+        expect(clearButton).toBeInTheDocument()
+    })
+
+    it('should clear text when clear button is clicked', async () => {
+         render(
+            <BrowserRouter>
+                <SearchBar />
+            </BrowserRouter>
+        )
+
+        const input = screen.getByPlaceholderText(/Search events, users/i) as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'test' } })
+
+        const clearButton = await screen.findByRole('button')
+        fireEvent.click(clearButton)
+
+        expect(input.value).toBe('')
+        expect(input).toHaveFocus()
+    })
+})


### PR DESCRIPTION
This PR adds a "Clear search" button to the `SearchBar` component, allowing users to quickly reset their query. This is a common pattern that improves usability.

Changes:
- **`client/src/components/ui/Input.tsx`**: Added `onRightIconClick` and `rightIconLabel` props. The wrapper `div` for `rightIcon` is now interactive (pointer-events allowed, role="button", tabIndex=0, aria-label) when these props are provided. It also handles the `disabled` state correctly.
- **`client/src/components/SearchBar.tsx`**: Updated to show a `CloseIcon` when there is a query and the component is not loading. Clicking the icon clears the query and refocuses the input.
- **`client/src/tests/components/SearchBar.test.tsx`**: Added new tests to verify the clear button appears and functions correctly.

Verified via Playwright script and manual inspection of screenshots. Tests passed.

---
*PR created automatically by Jules for task [8441085212391613947](https://jules.google.com/task/8441085212391613947) started by @burnoutberni*