### PR TITLE
Shield: Add input sanitization for federated ActivityPub content

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Stored XSS via ActivityPub Federation
+**Vulnerability:** Federated content (ActivityPub events, notes, profiles) often contains HTML. Backend ingestion (`src/federation.ts`) was extracting these fields directly without sanitization, leading to a Stored XSS vulnerability if the frontend or other consumers rendered this data unsafely.
+**Learning:** Backend ingestion must sanitize user-generated content before storage (defense in depth), even if the frontend has its own sanitization. Trusting the frontend is insufficient as other clients (mobile, API) might not be as secure.
+**Prevention:** Use `isomorphic-dompurify` at the ingress point (`src/federation.ts`) to sanitize HTML content using a strict whitelist, mirroring the frontend's security policy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,7 +1115,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1132,7 +1131,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1149,7 +1147,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1166,7 +1163,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1183,7 +1179,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1200,7 +1195,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1217,7 +1211,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1234,7 +1227,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1251,7 +1243,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1268,7 +1259,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1285,7 +1275,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1302,7 +1291,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1319,7 +1307,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1336,7 +1323,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1353,7 +1339,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1370,7 +1355,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1387,7 +1371,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1404,7 +1387,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1421,7 +1403,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1438,7 +1419,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1455,7 +1435,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1472,7 +1451,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1489,7 +1467,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1506,7 +1483,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1523,7 +1499,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1540,7 +1515,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2706,7 +2680,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2720,7 +2693,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2734,7 +2706,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2748,7 +2719,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2762,7 +2732,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2776,7 +2745,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2790,7 +2758,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2804,7 +2771,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2818,7 +2784,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2832,7 +2797,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2846,7 +2810,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2860,7 +2823,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2874,7 +2836,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2888,7 +2849,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2902,7 +2862,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2916,7 +2875,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2930,7 +2888,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2944,7 +2901,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2958,7 +2914,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2972,7 +2927,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2986,7 +2940,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3000,7 +2953,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3760,7 +3712,7 @@
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
 			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5503,7 +5455,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5535,7 +5486,7 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
 			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -6947,7 +6898,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7417,7 +7368,7 @@
 			"version": "4.21.0",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.27.0",
@@ -7503,7 +7454,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -11,6 +11,7 @@ import {
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
 import { safeFetch } from './lib/ssrfProtection.js'
+import { sanitizeHtml, sanitizeText } from './lib/sanitization.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
@@ -501,18 +502,24 @@ function getAttachmentUrl(attachment: unknown): string | null {
 	return null
 }
 
-function extractEventProperties(event: ActivityPubEvent | Record<string, unknown>) {
+export function extractEventProperties(event: ActivityPubEvent | Record<string, unknown>) {
 	const eventObj = event as Record<string, unknown>
 
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
 	const getNumber = (val: unknown) => (typeof val === 'number' ? val : null)
 
+	const rawSummary = getString(eventObj.summary)
+	const rawContent = getString(eventObj.content)
+	const rawName = getString(eventObj.name) || ''
+	const rawLocation = getLocationValue(eventObj.location)
+	const rawAttributedTo = getString(eventObj.attributedTo)
+
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: sanitizeText(rawName),
+		eventSummary: rawSummary ? sanitizeHtml(rawSummary) : null,
+		eventContent: rawContent ? sanitizeHtml(rawContent) : null,
+		locationValue: rawLocation ? sanitizeText(rawLocation) : null,
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -521,7 +528,7 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 		eventAttendanceMode: eventObj.eventAttendanceMode,
 		eventMaxCapacity: getNumber(eventObj.maximumAttendeeCapacity),
 		attachmentUrl: getAttachmentUrl(eventObj.attachment),
-		attributedTo: getString(eventObj.attributedTo),
+		attributedTo: rawAttributedTo ? sanitizeText(rawAttributedTo) : null,
 	}
 }
 
@@ -786,7 +793,8 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const rawContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = sanitizeHtml(rawContent)
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,8 +901,10 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const rawName = typeof eventObj.name === 'string' ? eventObj.name : ''
+	const eventName = sanitizeText(rawName)
+	const rawSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const eventSummary = rawSummary ? sanitizeHtml(rawSummary) : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
@@ -911,6 +921,10 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 		locationValue = eventLocation.name
 	} else {
 		locationValue = null
+	}
+
+	if (locationValue) {
+		locationValue = sanitizeText(locationValue)
 	}
 
 	await prisma.event.updateMany({
@@ -945,8 +959,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeHtml(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -5,14 +5,73 @@
 
 import DOMPurify from 'isomorphic-dompurify'
 
+// Configuration for safe HTML sanitization
+// Matches the client-side configuration in client/src/components/ui/SafeHTML.tsx
+const DOMPURIFY_CONFIG = {
+	ALLOWED_TAGS: [
+		'p',
+		'br',
+		'strong',
+		'b',
+		'em',
+		'i',
+		'u',
+		's',
+		'strike',
+		'del',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'ul',
+		'ol',
+		'li',
+		'a',
+		'blockquote',
+		'pre',
+		'code',
+		'span',
+		'div',
+	],
+	ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+	ALLOWED_URI_REGEXP: /^(https?:|mailto:|tel:|\/)/i,
+}
+
+// Hook function to add security attributes to external links
+// Same as in client/src/components/ui/SafeHTML.tsx
+const EXTERNAL_URL_REGEX = /^(https?:\/\/|\/\/)/i
+
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+	if (node.tagName === 'A' && node.hasAttribute('href')) {
+		const href = node.getAttribute('href')
+		if (href && EXTERNAL_URL_REGEX.test(href)) {
+			node.setAttribute('target', '_blank')
+			node.setAttribute('rel', 'noopener noreferrer')
+		}
+	}
+})
+
 /**
  * Sanitizes plain text (strips all HTML)
  * @param input - Raw text that may contain HTML
  * @returns Plain text with all HTML removed
  */
 export function sanitizeText(input: string): string {
+	if (!input) return ''
 	return DOMPurify.sanitize(input, {
 		ALLOWED_TAGS: [],
 		ALLOWED_ATTR: [],
 	})
+}
+
+/**
+ * Sanitizes HTML content allowing only safe tags
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML
+ */
+export function sanitizeHtml(input: string): string {
+	if (!input) return ''
+	return DOMPurify.sanitize(input, DOMPURIFY_CONFIG)
 }

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -43,7 +43,22 @@ const DOMPURIFY_CONFIG = {
 // Same as in client/src/components/ui/SafeHTML.tsx
 const EXTERNAL_URL_REGEX = /^(https?:\/\/|\/\/)/i
 
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+DOMPurify.addHook('afterSanitizeAttributes', (currentNode) => {
+	// Use type assertion with unknown to safely cast to a compatible interface
+	// This avoids "Unsafe member access on an error typed value" which happens
+	// when typescript-eslint can't infer the type of currentNode from the library
+	const node = currentNode as unknown as {
+		tagName: string
+		getAttribute: (name: string) => string | null
+		setAttribute: (name: string, value: string) => void
+		hasAttribute: (name: string) => boolean
+	}
+
+	// Defensive check
+	if (!node || typeof node.tagName !== 'string') {
+		return
+	}
+
 	if (node.tagName === 'A' && node.hasAttribute('href')) {
 		const href = node.getAttribute('href')
 		if (href && EXTERNAL_URL_REGEX.test(href)) {

--- a/src/tests/federation.sanitization.test.ts
+++ b/src/tests/federation.sanitization.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeHtml, sanitizeText } from '../lib/sanitization.js'
+import { extractEventProperties } from '../federation.js'
+
+describe('Federation Sanitization', () => {
+	describe('sanitizeHtml', () => {
+		it('should strip script tags', () => {
+			const input = '<p>Hello</p><script>alert("XSS")</script>'
+			const output = sanitizeHtml(input)
+			expect(output).toBe('<p>Hello</p>')
+		})
+
+		it('should strip iframe tags', () => {
+			const input = '<div><iframe src="javascript:alert(1)"></iframe></div>'
+			const output = sanitizeHtml(input)
+			expect(output).toBe('<div></div>')
+		})
+
+		it('should strip dangerous attributes', () => {
+			const input = '<a href="javascript:alert(1)" onclick="alert(1)">Link</a>'
+			const output = sanitizeHtml(input)
+			expect(output).toBe('<a>Link</a>')
+		})
+
+		it('should allow safe tags and attributes', () => {
+			const input = '<p><strong>Bold</strong> and <a href="https://example.com" title="Example">Link</a></p>'
+			const output = sanitizeHtml(input)
+			// Note: DOMPurify might reorder attributes or change quoting, but the structure should be preserved
+			expect(output).toContain('<p>')
+			expect(output).toContain('<strong>Bold</strong>')
+			expect(output).toContain('<a')
+			expect(output).toContain('href="https://example.com"')
+			expect(output).toContain('title="Example"')
+		})
+
+		it('should add target="_blank" and rel="noopener noreferrer" to external links', () => {
+			const input = '<a href="https://example.com">External</a>'
+			const output = sanitizeHtml(input)
+			expect(output).toContain('target="_blank"')
+			expect(output).toContain('rel="noopener noreferrer"')
+		})
+	})
+
+	describe('sanitizeText', () => {
+		it('should strip all HTML tags', () => {
+			const input = '<p>Hello <strong>World</strong></p>'
+			const output = sanitizeText(input)
+			expect(output).toBe('Hello World')
+		})
+	})
+
+	describe('extractEventProperties', () => {
+		it('should sanitize event name (text)', () => {
+			const event = {
+				id: 'https://example.com/events/1',
+				name: '<b>Event Name</b>',
+				summary: 'Summary',
+				content: 'Content',
+				startTime: '2023-01-01T00:00:00Z',
+			}
+			const props = extractEventProperties(event)
+			expect(props.eventName).toBe('Event Name')
+		})
+
+		it('should sanitize event summary (html)', () => {
+			const event = {
+				id: 'https://example.com/events/1',
+				name: 'Event',
+				summary: '<p>Summary <script>alert(1)</script></p>',
+				content: 'Content',
+				startTime: '2023-01-01T00:00:00Z',
+			}
+			const props = extractEventProperties(event)
+			expect(props.eventSummary).toBe('<p>Summary </p>')
+		})
+
+		it('should sanitize event content (html)', () => {
+			const event = {
+				id: 'https://example.com/events/1',
+				name: 'Event',
+				summary: 'Summary',
+				content: '<div onclick="alert(1)">Content</div>',
+				startTime: '2023-01-01T00:00:00Z',
+			}
+			const props = extractEventProperties(event)
+			expect(props.eventContent).toBe('<div>Content</div>')
+		})
+
+		it('should sanitize location name (text)', () => {
+			const event = {
+				id: 'https://example.com/events/1',
+				name: 'Event',
+				location: {
+					name: '<i>Location</i>',
+				},
+				startTime: '2023-01-01T00:00:00Z',
+			}
+			const props = extractEventProperties(event)
+			expect(props.locationValue).toBe('Location')
+		})
+
+		it('should sanitize attributedTo (text)', () => {
+			const event = {
+				id: 'https://example.com/events/1',
+				name: 'Event',
+				startTime: '2023-01-01T00:00:00Z',
+				attributedTo: '<a href="evil.com">User</a>',
+			}
+			const props = extractEventProperties(event)
+			expect(props.attributedTo).toBe('User')
+		})
+	})
+})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS via ActivityPub federation. Malicious HTML in federated events or notes could be stored in the database and executed on clients.
🎯 Impact: Attackers could inject scripts to steal sessions or perform actions on behalf of users viewing federated content.
🔧 Fix: Implemented backend sanitization using `isomorphic-dompurify` at the ingestion point (`src/federation.ts`).
✅ Verification: Added `src/tests/federation.sanitization.test.ts` to verify malicious tags are stripped.

---
*PR created automatically by Jules for task [8381531357433131195](https://jules.google.com/task/8381531357433131195) started by @burnoutberni*