### PR TITLE
feat(ui): add clear button and a11y to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -172,11 +172,33 @@ export function SearchBar() {
 		}
 	}
 
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		setSelectedIndex(-1)
+		inputRef.current?.focus()
+	}
+
 	const selectableItems = getSelectableItems()
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const clearButton = (
+		<button
+			type="button"
+			onClick={handleClear}
+			className="p-1 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-full"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	)
+
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		clearButton
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -188,8 +210,10 @@ export function SearchBar() {
 				onKeyDown={handleKeyDown}
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
+				aria-label="Search"
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={Boolean(query) && !isLoading}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -38,6 +38,11 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
+	/**
+	 * Whether the right icon should be interactive (clickable)
+	 * If true, removes 'pointer-events-none' from the icon container.
+	 */
+	rightIconInteractive?: boolean
 }
 
 /**
@@ -56,6 +61,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			leftIcon,
 			rightIcon,
 			fullWidth = false,
+			rightIconInteractive = false,
 			className,
 			id,
 			disabled,
@@ -157,7 +163,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Navbar.test.tsx
+++ b/client/src/tests/components/Navbar.test.tsx
@@ -210,7 +210,8 @@ describe('Navbar Component', () => {
 		render(<Navbar />, { wrapper })
 
 		// Search button should be visible on mobile (lg:hidden)
-		const searchButton = screen.getByLabelText('Search')
+		// Use getByRole to distinguish from the desktop search input which also has label "Search"
+		const searchButton = screen.getByRole('button', { name: 'Search' })
 		expect(searchButton).toBeInTheDocument()
 	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper, clearQueryClient } from '../testUtils'
+import { api } from '@/lib/api-client'
+
+// Mock api client
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+// Mock theme colors
+vi.mock('@/design-system', async () => {
+	const actual = await vi.importActual('@/design-system')
+	return {
+		...actual,
+		useThemeColors: () => ({ info: { 500: '#3b82f6' } }),
+	}
+})
+
+const { wrapper, queryClient } = createTestWrapper()
+
+describe('SearchBar Component', () => {
+	beforeEach(() => {
+		clearQueryClient(queryClient)
+		vi.clearAllMocks()
+        vi.useRealTimers() // SearchBar uses debounce with setTimeout
+	})
+
+	it('should render search input with correct aria-label', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByLabelText('Search')
+		expect(input).toBeInTheDocument()
+		expect(input).toHaveAttribute('placeholder', 'Search events, users, or @user@domain...')
+	})
+
+	it('should show clear button when text is entered', async () => {
+        const user = userEvent.setup()
+        vi.useRealTimers()
+
+        // Mock api.get to resolve immediately so loading finishes
+        vi.mocked(api.get).mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+		render(<SearchBar />, { wrapper })
+
+		const input = screen.getByLabelText('Search')
+		await user.type(input, 'test')
+
+        // Wait for loading to finish (debounce 300ms + async)
+        await waitFor(() => {
+            expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
+        }, { timeout: 2000 })
+
+		const clearButton = screen.getByLabelText('Clear search')
+		expect(clearButton).toBeInTheDocument()
+	})
+
+	it('should clear input when clear button is clicked', async () => {
+        const user = userEvent.setup()
+        vi.useRealTimers()
+
+        vi.mocked(api.get).mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+		render(<SearchBar />, { wrapper })
+
+		const input = screen.getByLabelText('Search')
+		await user.type(input, 'test')
+
+        // Wait for loading to finish
+        await waitFor(() => {
+            expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
+        }, { timeout: 2000 })
+
+		const clearButton = screen.getByLabelText('Clear search')
+		await user.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+        expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+	})
+
+    it('should show results when searching', async () => {
+        const user = userEvent.setup()
+        vi.useRealTimers()
+
+        // Mock API response
+        vi.mocked(api.get).mockResolvedValue({
+            users: [
+                { id: '1', username: 'testuser', name: 'Test User' }
+            ],
+            events: [],
+            remoteAccountSuggestion: null
+        })
+
+        render(<SearchBar />, { wrapper })
+
+        const input = screen.getByLabelText('Search')
+        await user.type(input, 'test')
+
+        await waitFor(() => {
+            expect(api.get).toHaveBeenCalled()
+        }, { timeout: 2000 })
+
+        // Results should appear
+        await waitFor(() => {
+            expect(screen.getByText(/testuser/i)).toBeInTheDocument()
+        })
+    })
+})


### PR DESCRIPTION
This PR implements a clear button in the SearchBar component to improve UX and accessibility.

Changes:
- `client/src/components/ui/Input.tsx`: Added `rightIconInteractive` prop to allow clicking the right icon.
- `client/src/components/SearchBar.tsx`: 
    - Added logic to show a clear button when the search query is not empty.
    - Added `handleClear` function to reset search state and focus the input.
    - Added `aria-label="Search"` to the input.
- `client/src/tests/components/SearchBar.test.tsx`: Added comprehensive tests for rendering, clearing interaction, and accessibility.

This addresses the missing accessible name for the search input and provides a convenient way to clear the search query.

---
*PR created automatically by Jules for task [13212839662214734073](https://jules.google.com/task/13212839662214734073) started by @burnoutberni*