### PR TITLE
🎨 Palette: Add focus trapping to Modal for better accessibility

### DIFF
--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -79,6 +79,70 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 		ref
 	) => {
 		const contentRef = useRef<HTMLDivElement>(null)
+		const previousFocusRef = useRef<HTMLElement | null>(null)
+
+		// Handle focus trap and restoration
+		useEffect(() => {
+			if (isOpen) {
+				// Store current focus
+				previousFocusRef.current = document.activeElement as HTMLElement
+
+				// Focus the first focusable element
+				const focusableElements = contentRef.current?.querySelectorAll(
+					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+
+				if (focusableElements && focusableElements.length > 0) {
+					// Use requestAnimationFrame to ensure the modal is fully rendered
+					requestAnimationFrame(() => {
+						;(focusableElements[0] as HTMLElement).focus()
+					})
+				} else if (contentRef.current) {
+					contentRef.current.focus()
+				}
+
+				// Restore focus when modal closes or unmounts
+				return () => {
+					if (previousFocusRef.current) {
+						previousFocusRef.current.focus()
+						previousFocusRef.current = null
+					}
+				}
+			}
+		}, [isOpen])
+
+		// Handle tab key for focus trapping
+		useEffect(() => {
+			if (!isOpen) return
+
+			function handleTabKey(e: KeyboardEvent) {
+				if (e.key !== 'Tab') return
+
+				const focusableElements = contentRef.current?.querySelectorAll(
+					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+
+				if (!focusableElements || focusableElements.length === 0) return
+
+				const firstElement = focusableElements[0] as HTMLElement
+				const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+				if (e.shiftKey) {
+					if (document.activeElement === firstElement) {
+						lastElement.focus()
+						e.preventDefault()
+					}
+				} else {
+					if (document.activeElement === lastElement) {
+						firstElement.focus()
+						e.preventDefault()
+					}
+				}
+			}
+
+			document.addEventListener('keydown', handleTabKey)
+			return () => document.removeEventListener('keydown', handleTabKey)
+		}, [isOpen])
 
 		// Handle escape key
 		useEffect(() => {

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -56,6 +56,9 @@ const maxWidthClasses = {
 	full: 'max-w-full m-4',
 }
 
+const FOCUSABLE_ELEMENTS_SELECTOR =
+	'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
 /**
  * Modal component for displaying content in an overlay.
  * Handles backdrop, escape key, and click-outside-to-close functionality.
@@ -89,7 +92,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 
 				// Focus the first focusable element
 				const focusableElements = contentRef.current?.querySelectorAll(
-					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+					FOCUSABLE_ELEMENTS_SELECTOR
 				)
 
 				if (focusableElements && focusableElements.length > 0) {
@@ -113,16 +116,22 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 
 		// Handle tab key for focus trapping
 		useEffect(() => {
-			if (!isOpen) return
+			if (!isOpen) {
+				return
+			}
 
 			function handleTabKey(e: KeyboardEvent) {
-				if (e.key !== 'Tab') return
+				if (e.key !== 'Tab') {
+					return
+				}
 
 				const focusableElements = contentRef.current?.querySelectorAll(
-					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+					FOCUSABLE_ELEMENTS_SELECTOR
 				)
 
-				if (!focusableElements || focusableElements.length === 0) return
+				if (!focusableElements || focusableElements.length === 0) {
+					return
+				}
 
 				const firstElement = focusableElements[0] as HTMLElement
 				const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement

--- a/client/src/tests/components/Modal.test.tsx
+++ b/client/src/tests/components/Modal.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Modal } from '../../components/ui/Modal'
 import { createTestWrapper } from '../testUtils'
+import React, { useState } from 'react'
 
 describe('Modal Component', () => {
 	const { wrapper } = createTestWrapper()
@@ -139,5 +140,70 @@ describe('Modal Component', () => {
 		mockOnClose.mockClear()
 		await user.keyboard('{Escape}')
 		expect(mockOnClose).not.toHaveBeenCalled()
+	})
+
+	const FocusTestComponent = () => {
+		const [isOpen, setIsOpen] = useState(false)
+		return (
+			<div>
+				<button onClick={() => setIsOpen(true)}>Open Modal</button>
+				<Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+					<button>Button 1</button>
+					<button>Button 2</button>
+					<input type="text" placeholder="Input" />
+				</Modal>
+			</div>
+		)
+	}
+
+	it('focus is trapped inside the modal when open', async () => {
+		const user = userEvent.setup()
+		render(<FocusTestComponent />, { wrapper })
+
+		// Open modal
+		await user.click(screen.getByText('Open Modal'))
+
+		// Initial focus should be on the first focusable element inside modal
+		// Using waitFor because focus shift might happen in useEffect/animation frame
+		await waitFor(() => expect(screen.getByText('Button 1')).toHaveFocus())
+
+		// Tab to next element
+		await user.tab()
+		expect(screen.getByText('Button 2')).toHaveFocus()
+
+		// Tab to input
+		await user.tab()
+		expect(screen.getByPlaceholderText('Input')).toHaveFocus()
+
+		// Tab from last element (input) should cycle back to first (Button 1)
+		await user.tab()
+		expect(screen.getByText('Button 1')).toHaveFocus()
+
+		// Shift+Tab from first element (Button 1) should cycle to last (input)
+		await user.keyboard('{Shift>}{Tab}{/Shift}')
+		expect(screen.getByPlaceholderText('Input')).toHaveFocus()
+	})
+
+	it('focus is restored to previous element when modal closes', async () => {
+		const user = userEvent.setup()
+		render(<FocusTestComponent />, { wrapper })
+
+		const trigger = screen.getByText('Open Modal')
+
+		// Ensure trigger has focus initially
+		trigger.focus()
+		expect(trigger).toHaveFocus()
+
+		// Open modal
+		await user.click(trigger)
+
+		// Modal opens, focus moves inside
+		await waitFor(() => expect(screen.getByText('Button 1')).toHaveFocus())
+
+		// Close modal via Escape
+		await user.keyboard('{Escape}')
+
+		// Focus should return to trigger
+		await waitFor(() => expect(trigger).toHaveFocus())
 	})
 })


### PR DESCRIPTION
Implemented focus trapping and restoration in the `Modal` component to improve accessibility. The modal now captures focus when opened, cycles focus within its content when Tabbing, and restores focus to the triggering element when closed or unmounted. Added tests to verify this behavior.

---
*PR created automatically by Jules for task [17331058244624649532](https://jules.google.com/task/17331058244624649532) started by @burnoutberni*