### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -174,9 +174,25 @@ export function SearchBar() {
 
 	const selectableItems = getSelectableItems()
 
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const rightElement = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<button
+			onClick={handleClear}
+			className="text-text-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-primary-500 rounded-full p-0.5"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +205,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightElement}
+				rightIconInteractive={Boolean(query) && !isLoading}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,11 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive
+	 * @default false
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +60,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +163,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -73,6 +73,20 @@ describe('Input Component', () => {
 		expect(input).toBeInTheDocument()
 	})
 
+	it('should make right icon interactive when rightIconInteractive is true', () => {
+		render(
+			<Input
+				type="text"
+				rightIcon={<button aria-label="Clear">Clear</button>}
+				rightIconInteractive
+			/>
+		)
+
+		const clearButton = screen.getByRole('button', { name: 'Clear' })
+		const iconContainer = clearButton.parentElement
+		expect(iconContainer).not.toHaveClass('pointer-events-none')
+	})
+
 	it('should handle value changes', () => {
 		const handleChange = vi.fn()
 		render(<Input type="text" onChange={handleChange} />)

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,9 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { SearchBar } from '../../components/SearchBar'
-import { createTestWrapper } from '../testUtils'
+import { api } from '../../lib/api-client'
+import { createTestWrapper, clearQueryClient } from '../testUtils'
 
-// Mock the API client
+// Mock dependencies
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+	const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+	return {
+		...actual,
+		useNavigate: () => mockNavigate,
+	}
+})
+
 vi.mock('../../lib/api-client', () => ({
 	api: {
 		get: vi.fn(),
@@ -11,30 +22,193 @@ vi.mock('../../lib/api-client', () => ({
 	},
 }))
 
+const { wrapper, queryClient } = createTestWrapper()
+
 describe('SearchBar', () => {
-	it('should render input element', () => {
-		const { wrapper } = createTestWrapper()
-		render(<SearchBar />, { wrapper })
-		const input = screen.getByRole('textbox')
-		expect(input).toBeInTheDocument()
+	beforeEach(() => {
+		clearQueryClient(queryClient)
+		vi.clearAllMocks()
+		vi.useFakeTimers()
 	})
 
-	it('should show clear button when text is entered', async () => {
-		const { wrapper } = createTestWrapper()
-		render(<SearchBar />, { wrapper })
+	afterEach(() => {
+		vi.useRealTimers()
+	})
 
+	const mockSearchResults = {
+		users: [{ id: '1', username: 'testuser', name: 'Test User' }],
+		events: [{ id: '2', title: 'Test Event', startTime: new Date().toISOString(), user: { username: 'host' } }],
+		remoteAccountSuggestion: null,
+	};
+
+	it('should render input element', () => {
+		render(<SearchBar />, { wrapper })
+		expect(screen.getByRole('textbox')).toBeInTheDocument()
+	})
+
+	it('should debounce search requests', async () => {
+		render(<SearchBar />, { wrapper })
 		const input = screen.getByRole('textbox')
+
 		fireEvent.change(input, { target: { value: 'test' } })
 
-		// The clear button should appear
-		// This test expects the "Clear search" button which doesn't exist yet
-		const clearButton = await screen.findByRole('button', { name: /clear search/i })
+		// Fast forward less than debounce time (300ms)
+		act(() => {
+			vi.advanceTimersByTime(200)
+		})
+		expect(api.get).not.toHaveBeenCalled()
+
+		// Fast forward to complete debounce
+		await act(async () => {
+			vi.advanceTimersByTime(150)
+		})
+
+		expect(api.get).toHaveBeenCalledWith('/user-search', expect.objectContaining({ q: 'test' }))
+	})
+
+	it('should display search results', async () => {
+		vi.mocked(api.get).mockResolvedValue(mockSearchResults)
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		expect(screen.getByText(/testuser/)).toBeInTheDocument()
+		expect(screen.getByText(/Test Event/)).toBeInTheDocument()
+	})
+
+	it('should show clear button and clear search', async () => {
+		// Mock empty results to avoid rendering dropdown
+		vi.mocked(api.get).mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Wait for loading to finish
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		const clearButton = screen.getByRole('button', { name: /clear search/i })
 		expect(clearButton).toBeInTheDocument()
 
-		// Click clear button
 		fireEvent.click(clearButton)
 
-		// Input should be cleared
 		expect(input).toHaveValue('')
+		expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument()
+		expect(input).toHaveFocus()
+	})
+
+	it('should handle keyboard navigation', async () => {
+		vi.mocked(api.get).mockResolvedValue(mockSearchResults)
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		expect(screen.getByText(/testuser/)).toBeInTheDocument()
+
+		// ArrowDown to select first item (user)
+		fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+		// ArrowDown to select second item (event)
+		fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+		// Enter to navigate
+		fireEvent.keyDown(input, { key: 'Enter' })
+
+		expect(mockNavigate).toHaveBeenCalledWith('/@host/2')
+	})
+
+	it('should navigate to user profile on click', async () => {
+		vi.mocked(api.get).mockResolvedValue(mockSearchResults)
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		expect(screen.getByText(/testuser/)).toBeInTheDocument()
+
+		const userItem = screen.getByText(/testuser/)
+		fireEvent.click(userItem)
+
+		expect(mockNavigate).toHaveBeenCalledWith('/@testuser')
+	})
+
+	it('should handle remote account resolution', async () => {
+		const remoteResults = {
+			users: [],
+			events: [],
+			remoteAccountSuggestion: {
+				handle: '@remote@instance.com',
+				username: 'remote',
+				domain: 'instance.com',
+			},
+		}
+
+		const resolvedUser = { user: { id: 'remote1', username: 'remote_resolved' } }
+
+		vi.mocked(api.get).mockResolvedValue(remoteResults)
+		vi.mocked(api.post).mockResolvedValue(resolvedUser)
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: '@remote@instance.com' } })
+
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		expect(screen.getByText('@remote@instance.com')).toBeInTheDocument()
+
+		const remoteItem = screen.getByText('Lookup remote account')
+		fireEvent.click(remoteItem)
+
+		expect(api.post).toHaveBeenCalledWith('/user-search/resolve', { handle: '@remote@instance.com' }, undefined, 'Failed to resolve account')
+
+		// Wait for async resolution
+		await act(async () => {
+			await Promise.resolve()
+            await Promise.resolve()
+		})
+
+		expect(mockNavigate).toHaveBeenCalledWith('/@remote_resolved')
+	})
+
+	it('should close on Escape', async () => {
+		vi.mocked(api.get).mockResolvedValue(mockSearchResults)
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await act(async () => {
+			vi.advanceTimersByTime(400)
+		})
+
+		expect(screen.getByText(/testuser/)).toBeInTheDocument()
+
+		fireEvent.keyDown(input, { key: 'Escape' })
+
+		expect(screen.queryByText(/testuser/)).not.toBeInTheDocument()
 	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Mock the API client
+vi.mock('../../lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar', () => {
+	it('should render input element', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox')
+		expect(input).toBeInTheDocument()
+	})
+
+	it('should show clear button when text is entered', async () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+
+		const input = screen.getByRole('textbox')
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// The clear button should appear
+		// This test expects the "Clear search" button which doesn't exist yet
+		const clearButton = await screen.findByRole('button', { name: /clear search/i })
+		expect(clearButton).toBeInTheDocument()
+
+		// Click clear button
+		fireEvent.click(clearButton)
+
+		// Input should be cleared
+		expect(input).toHaveValue('')
+	})
+})


### PR DESCRIPTION
💡 **What**: Added a "Clear" (X) button to the `SearchBar` component that appears when there is text input.
🎯 **Why**: To allow users to quickly reset their search query without manually deleting text, improving usability on both desktop and mobile.
📸 **Before/After**: See verified screenshots in `/home/jules/verification/`. Before: No clear button. After: Clear button appears and clears text on click.
♿ **Accessibility**: The button has `aria-label="Clear search"` and is keyboard accessible.


---
*PR created automatically by Jules for task [15633013069833576634](https://jules.google.com/task/15633013069833576634) started by @burnoutberni*