### PR TITLE
🎨 Palette: Search Bar Clear Button & Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Interactive Input Icons
+**Learning:** The `Input` component's `rightIcon` was non-interactive by default (`pointer-events-none`), preventing accessible controls like "Clear" buttons inside inputs.
+**Action:** Added `rightIconInteractive` prop to `Input` to allow clickable icons while maintaining default behavior. This enables accessible search clearing patterns.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -172,11 +172,27 @@ export function SearchBar() {
 		}
 	}
 
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	const selectableItems = getSelectableItems()
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const rightElement = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<button
+			onClick={handleClear}
+			className="text-text-tertiary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 rounded-full p-0.5"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +205,9 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightElement}
+				rightIconInteractive={Boolean(query) && !isLoading}
+				aria-label="Search events, users, or remote accounts"
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (pointer-events-auto)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,37 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should allow interaction with right icon when rightIconInteractive is true', () => {
+		const handleIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<button onClick={handleIconClick}>Click me</button>}
+				rightIconInteractive
+			/>
+		)
+
+		const button = screen.getByText('Click me')
+		// Check that the parent div does NOT have pointer-events-none
+		// The parent of the button is the div with the class.
+		const iconContainer = button.parentElement
+		expect(iconContainer).not.toHaveClass('pointer-events-none')
+
+		fireEvent.click(button)
+		expect(handleIconClick).toHaveBeenCalledTimes(1)
+	})
+
+	it('should prevent interaction with right icon when rightIconInteractive is false', () => {
+		render(
+			<Input
+				type="text"
+				rightIcon={<span>Icon</span>}
+			/>
+		)
+
+		const icon = screen.getByText('Icon')
+		const iconContainer = icon.parentElement
+		expect(iconContainer).toHaveClass('pointer-events-none')
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+import { SearchBar } from '../../components/SearchBar'
+import { ThemeProvider } from '@/design-system'
+
+// Mock API client
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+const createWrapper = () => {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	})
+
+	return ({ children }: { children: React.ReactNode }) => (
+		<ThemeProvider>
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter>{children}</MemoryRouter>
+			</QueryClientProvider>
+		</ThemeProvider>
+	)
+}
+
+describe('SearchBar Component', () => {
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper: createWrapper() })
+		expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+	})
+
+	it('should show clear button when typing', async () => {
+		render(<SearchBar />, { wrapper: createWrapper() })
+
+		const input = screen.getByPlaceholderText(/search/i)
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		// Clear button should appear
+		const clearButton = await screen.findByLabelText('Clear search')
+		expect(clearButton).toBeInTheDocument()
+	})
+
+	it('should clear input when clear button is clicked', async () => {
+		render(<SearchBar />, { wrapper: createWrapper() })
+
+		const input = screen.getByPlaceholderText(/search/i) as HTMLInputElement
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		const clearButton = await screen.findByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		expect(input.value).toBe('')
+		expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+	})
+
+	it('should focus input after clearing', async () => {
+		render(<SearchBar />, { wrapper: createWrapper() })
+
+		const input = screen.getByPlaceholderText(/search/i)
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		const clearButton = await screen.findByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveFocus()
+	})
+})

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,5 +1,6 @@
+import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 


### PR DESCRIPTION
💡 What: Added a clear button (X icon) to the search bar when a query is present. This button clears the input, resets results, and refocuses the input. Also added `aria-label` to the search input and the clear button.
🎯 Why: Users need an easy way to clear their search query without manually deleting text. This is a standard and expected UX pattern.
♿ Accessibility: Added `aria-label` to `Input` (via `SearchBar`) and the clear button. Allowed interaction with `rightIcon` in `Input` via new `rightIconInteractive` prop.

---
*PR created automatically by Jules for task [9849036458274229926](https://jules.google.com/task/9849036458274229926) started by @burnoutberni*