### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in ActivityPub Federation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Stored XSS via ActivityPub
+**Vulnerability:** ActivityPub content (summary, content) was stored unsanitized in the database.
+**Learning:** Federation logic acts as a second ingress point for user content and must be sanitized just like API endpoints. `sanitizeText` was too aggressive for this use case as it strips all HTML.
+**Prevention:** Ensure all ingress points (API, Federation, etc.) sanitize HTML content if the system supports rich text. Use `DOMPurify` with a strict allowlist.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -11,6 +11,7 @@ import {
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
 import { safeFetch } from './lib/ssrfProtection.js'
+import { sanitizeHtml } from './lib/sanitization.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
@@ -510,8 +511,12 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 	return {
 		eventId: getString(eventObj.id) || '',
 		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
+		eventSummary: getString(eventObj.summary)
+			? sanitizeHtml(getString(eventObj.summary)!)
+			: null,
+		eventContent: getString(eventObj.content)
+			? sanitizeHtml(getString(eventObj.content)!)
+			: null,
 		locationValue: getLocationValue(eventObj.location),
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
@@ -786,7 +791,7 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = typeof noteObj.content === 'string' ? sanitizeHtml(noteObj.content) : ''
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -16,3 +16,44 @@ export function sanitizeText(input: string): string {
 		ALLOWED_ATTR: [],
 	})
 }
+
+/**
+ * Sanitizes HTML content, allowing only safe tags and attributes
+ * Used for ActivityPub content (remote events, comments) which may contain HTML
+ * Matches the frontend SafeHTML component configuration
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, {
+		ALLOWED_TAGS: [
+			'p',
+			'br',
+			'strong',
+			'b',
+			'em',
+			'i',
+			'u',
+			's',
+			'strike',
+			'del',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'ul',
+			'ol',
+			'li',
+			'a',
+			'blockquote',
+			'pre',
+			'code',
+			'span',
+			'div',
+		],
+		ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+		ALLOWED_URI_REGEXP: /^(https?:|mailto:|tel:|\/)/i,
+	})
+}

--- a/src/tests/sanitization.test.ts
+++ b/src/tests/sanitization.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeHtml, sanitizeText } from '../lib/sanitization.js'
+
+describe('Sanitization', () => {
+    describe('sanitizeHtml', () => {
+        it('should strip script tags', () => {
+            const input = '<script>alert(1)</script>Hello'
+            expect(sanitizeHtml(input)).toBe('Hello')
+        })
+
+        it('should strip iframe tags', () => {
+            const input = '<iframe src="javascript:alert(1)"></iframe>Hello'
+            expect(sanitizeHtml(input)).toBe('Hello')
+        })
+
+        it('should strip object tags', () => {
+            const input = '<object data="javascript:alert(1)"></object>Hello'
+            expect(sanitizeHtml(input)).toBe('Hello')
+        })
+
+        it('should allow safe tags', () => {
+            const input = '<b>Bold</b> <i>Italic</i> <a href="https://example.com">Link</a>'
+            expect(sanitizeHtml(input)).toBe('<b>Bold</b> <i>Italic</i> <a href="https://example.com">Link</a>')
+        })
+
+        it('should strip unsafe attributes', () => {
+            const input = '<a href="https://example.com" onclick="alert(1)">Link</a>'
+            expect(sanitizeHtml(input)).toBe('<a href="https://example.com">Link</a>')
+        })
+
+        it('should strip javascript: href', () => {
+            const input = '<a href="javascript:alert(1)">Link</a>'
+            // DOMPurify typically removes the whole href attribute or the tag depending on config,
+            // but here it should strip the href content or the attribute.
+            // Let's expect it to not contain javascript:
+            const output = sanitizeHtml(input)
+            expect(output).not.toContain('javascript:')
+        })
+
+        it('should allow headings', () => {
+            const input = '<h1>Title</h1>'
+            expect(sanitizeHtml(input)).toBe('<h1>Title</h1>')
+        })
+    })
+
+    describe('sanitizeText', () => {
+        it('should strip all tags', () => {
+            const input = '<b>Bold</b>'
+            expect(sanitizeText(input)).toBe('Bold')
+        })
+    })
+})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS via ActivityPub federation. Incoming events and comments (notes) were stored unsanitized in the database. Malicious HTML (e.g., `<script>`) in `summary` or `content` fields would be stored and potentially executed when rendered by clients that do not strictly sanitize output (or rely on backend sanitization).
🎯 Impact: An attacker on a remote instance could inject malicious scripts into the timelines of local users by federating crafted activities.
🔧 Fix: Implemented `sanitizeHtml` using `DOMPurify` (matching frontend configuration) and applied it to all ingress points in `src/federation.ts` (`extractEventProperties`, `handleCreateNote`).
✅ Verification: Added unit tests in `src/tests/sanitization.test.ts` confirming that dangerous tags are stripped while safe HTML is preserved. Ran existing federation tests to ensure no regressions.

---
*PR created automatically by Jules for task [13747777354380612911](https://jules.google.com/task/13747777354380612911) started by @burnoutberni*