### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS via Malicious ActivityPub URLs

### DIFF
--- a/src/federation.ts
+++ b/src/federation.ts
@@ -16,6 +16,7 @@ import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
 import { prisma } from './lib/prisma.js'
 import { trackInstance } from './lib/instanceHelpers.js'
+import { sanitizeUrl } from './lib/sanitization.js'
 import { logger } from './lib/logger.js'
 import type { Prisma, Event, User } from '@prisma/client'
 import type {
@@ -516,11 +517,11 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
-		eventUrl: getString(eventObj.url),
+		eventUrl: sanitizeUrl(getString(eventObj.url)),
 		eventStatus: eventObj.eventStatus,
 		eventAttendanceMode: eventObj.eventAttendanceMode,
 		eventMaxCapacity: getNumber(eventObj.maximumAttendeeCapacity),
-		attachmentUrl: getAttachmentUrl(eventObj.attachment),
+		attachmentUrl: sanitizeUrl(getAttachmentUrl(eventObj.attachment)),
 		attributedTo: getString(eventObj.attributedTo),
 	}
 }
@@ -948,8 +949,8 @@ async function handleUpdatePerson(person: Person | Record<string, unknown>): Pro
 	const personName = personObj.name || undefined
 	const personSummary = personObj.summary || undefined
 	const personDisplayColor = personObj.displayColor || undefined
-	const personIconUrl = personObj.icon?.url || undefined
-	const personImageUrl = personObj.image?.url || undefined
+	const personIconUrl = sanitizeUrl(personObj.icon?.url || undefined)
+	const personImageUrl = sanitizeUrl(personObj.image?.url || undefined)
 	const personPreferredUsername = personObj.preferredUsername
 
 	await prisma.user.updateMany({

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -25,6 +25,7 @@ export function sanitizeText(input: string): string {
  */
 export function sanitizeUrl(url: undefined): undefined
 export function sanitizeUrl(url: string | null): string | null
+export function sanitizeUrl(url: string | undefined): string | undefined
 export function sanitizeUrl(url: string | null | undefined): string | null | undefined {
 	if (url === undefined) {
 		return undefined

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -16,3 +16,29 @@ export function sanitizeText(input: string): string {
 		ALLOWED_ATTR: [],
 	})
 }
+
+/**
+ * Sanitizes a URL to ensure it uses a safe protocol (http/https)
+ * Preserves undefined to avoid overwriting fields in partial updates.
+ * @param url - The URL to sanitize
+ * @returns The URL if safe, null if unsafe/invalid/null, undefined if input was undefined
+ */
+export function sanitizeUrl(url: undefined): undefined
+export function sanitizeUrl(url: string | null): string | null
+export function sanitizeUrl(url: string | null | undefined): string | null | undefined {
+	if (url === undefined) {
+		return undefined
+	}
+	if (!url) {
+		return null
+	}
+	try {
+		const parsed = new URL(url)
+		if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+			return url
+		}
+		return null
+	} catch {
+		return null
+	}
+}

--- a/src/tests/federation_security.test.ts
+++ b/src/tests/federation_security.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { config } from 'dotenv'
+config()
+import { handleActivity } from '../federation.js'
+import { ActivityType, ObjectType } from '../constants/activitypub.js'
+import { prisma } from '../lib/prisma.js'
+import * as activitypubHelpers from '../lib/activitypubHelpers.js'
+import * as realtime from '../realtime.js'
+
+vi.mock('../lib/activitypubHelpers.js')
+vi.mock('../services/ActivityBuilder.js')
+vi.mock('../services/ActivityDelivery.js')
+vi.mock('../realtime.js')
+
+describe('Federation Security', () => {
+	beforeEach(async () => {
+		await prisma.processedActivity.deleteMany({})
+		await prisma.event.deleteMany({})
+		await prisma.user.deleteMany({})
+		vi.clearAllMocks()
+	})
+
+	it('should NOT store javascript: URLs in event url field', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/attacker',
+			type: 'Person',
+			preferredUsername: 'attacker',
+			inbox: 'https://example.com/users/attacker/inbox',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'attacker@example.com',
+				email: 'attacker@example.com',
+				name: 'Attacker',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+				inboxUrl: remoteActor.inbox,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+		vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+		const activity = {
+			id: 'https://example.com/activities/create-malicious-1',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/malicious-event-1',
+				name: 'Malicious Event',
+				startTime: new Date().toISOString(),
+				url: 'javascript:alert(1)', // malicious URL
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const event = await prisma.event.findFirst({
+			where: {
+				externalId: activity.object.id,
+			},
+		})
+
+		expect(event).toBeTruthy()
+		// Expectation: The URL should be null or sanitized, NOT javascript:alert(1)
+		expect(event?.url).not.toBe('javascript:alert(1)')
+	})
+})


### PR DESCRIPTION
*   🚨 Severity: HIGH
*   💡 Vulnerability: ActivityPub federation handlers were accepting `javascript:` URLs in event `url` and profile image fields. This could lead to Stored XSS when these fields are rendered in the frontend (e.g. `<a href={event.url}>`).
*   🎯 Impact: An attacker could inject malicious JavaScript via a crafted ActivityPub `Create` or `Update` activity, which would execute when a user views the event or profile.
*   🔧 Fix: Added `sanitizeUrl` to `src/lib/sanitization.ts` to enforce `http` and `https` protocols. Applied this sanitization to `eventUrl`, `headerImage`, `icon`, and `image` fields in `src/federation.ts`.
*   ✅ Verification: Added a regression test `src/tests/federation_security.test.ts` which confirms that `javascript:` URLs are rejected. Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [18228277507117330749](https://jules.google.com/task/18228277507117330749) started by @burnoutberni*