### PR TITLE
🎨 Palette: Add Clear Search Button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Interactive Input Icons
+**Learning:** The `Input` component used `pointer-events-none` on right icons by default, preventing interactions like clear buttons. Added `rightIconInteractive` prop to optionally allow clicks.
+**Action:** Use `rightIconInteractive={true}` when adding clickable elements (buttons, toggles) inside inputs.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,25 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
+	const clearButton =
+		query && !isLoading ? (
+			<button
+				type="button"
+				onClick={handleClear}
+				className="text-text-tertiary hover:text-text-primary focus:outline-none focus:text-text-primary transition-colors p-1"
+				aria-label="Clear search">
+				<CloseIcon className="w-4 h-4" />
+			</button>
+		) : undefined
+
+	const rightIcon = isLoading ? <Spinner size="sm" variant="secondary" /> : clearButton
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +207,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={Boolean(clearButton)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,19 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should allow interaction with right icon when rightIconInteractive is true', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={<button onClick={handleClick}>Click me</button>}
+				rightIconInteractive
+			/>
+		)
+
+		const button = screen.getByText('Click me')
+		fireEvent.click(button)
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { SearchBar } from '../../components/SearchBar'
 import { api } from '@/lib/api-client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider } from '@/design-system'
+import React from 'react'
 
 // Mock api client
 vi.mock('@/lib/api-client', () => ({
@@ -46,7 +47,8 @@ describe('SearchBar Component', () => {
     expect(input).toBeInTheDocument()
 
     // Setup mock
-    ;(api.get as any).mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+    const mockGet = api.get as unknown as ReturnType<typeof vi.fn>
+    mockGet.mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
 
     // Type query
     await act(async () => {
@@ -82,9 +84,13 @@ describe('SearchBar Component', () => {
       const input = screen.getByRole('textbox')
 
       // Mock a slow response
-      let resolvePromise: (val: any) => void = () => {};
-      const promise = new Promise((resolve) => { resolvePromise = resolve });
-      (api.get as any).mockReturnValue(promise)
+      // eslint-disable-next-line no-unused-vars
+      let resolvePromise: (val: unknown) => void = () => {};
+      const promise = new Promise((resolve) => {
+          resolvePromise = resolve
+      });
+      const mockGet = api.get as unknown as ReturnType<typeof vi.fn>
+      mockGet.mockReturnValue(promise)
 
       await act(async () => {
           fireEvent.change(input, { target: { value: 'loading test' } })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { api } from '@/lib/api-client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '@/design-system'
+
+// Mock api client
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('SearchBar Component', () => {
+  it('should show clear button when text is entered and clear it when clicked', async () => {
+    const wrapper = createWrapper()
+    render(<SearchBar />, { wrapper })
+
+    const input = screen.getByRole('textbox')
+    expect(input).toBeInTheDocument()
+
+    // Setup mock
+    ;(api.get as any).mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+
+    // Type query
+    await act(async () => {
+        fireEvent.change(input, { target: { value: 'test' } })
+    })
+
+    expect(input).toHaveValue('test')
+
+    // Wait for clear button
+    const clearButton = await screen.findByLabelText('Clear search', {}, { timeout: 2000 })
+    expect(clearButton).toBeInTheDocument()
+
+    // Click clear
+    await act(async () => {
+        fireEvent.click(clearButton)
+    })
+
+    // Verify cleared
+    expect(input).toHaveValue('')
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+  })
+
+  it('should render search input', () => {
+    const wrapper = createWrapper()
+    render(<SearchBar />, { wrapper })
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('should show loading spinner while searching', async () => {
+      const wrapper = createWrapper()
+      render(<SearchBar />, { wrapper })
+
+      const input = screen.getByRole('textbox')
+
+      // Mock a slow response
+      let resolvePromise: (val: any) => void = () => {};
+      const promise = new Promise((resolve) => { resolvePromise = resolve });
+      (api.get as any).mockReturnValue(promise)
+
+      await act(async () => {
+          fireEvent.change(input, { target: { value: 'loading test' } })
+      })
+
+      await new Promise(resolve => setTimeout(resolve, 350))
+
+      expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+
+      // Cleanup promise
+      await act(async () => {
+         if (resolvePromise) resolvePromise({ users: [], events: [] });
+      })
+  })
+})


### PR DESCRIPTION
Added a "Clear Search" button (X icon) to the search bar that appears when there is text. This allows users to quickly reset their search query. Updated the `Input` component to support interactive right icons via a new `rightIconInteractive` prop.

Verified with unit tests and frontend screenshots.
![Screenshot showing filled search bar](verification_1_filled.png)
![Screenshot showing cleared search bar](verification_2_cleared.png)

---
*PR created automatically by Jules for task [6200472402353184528](https://jules.google.com/task/6200472402353184528) started by @burnoutberni*