### PR TITLE
🛡️ Sentinel: Fix Stored XSS in Federation Input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-12 - Inconsistent Input Sanitization for Federated Content
+**Vulnerability:** Federated content (ActivityPub events and notes) was stored in the database without sanitization, while local user content was sanitized. This allowed federated instances to inject arbitrary HTML (Stored XSS) or bypass content restrictions.
+**Learning:** Security controls applied to local users (e.g., input sanitization in API endpoints) must also be applied to data ingested from external sources (federation). Trust boundaries are critical.
+**Prevention:** Ensure that all ingress points (API, Federation, Webhooks) pass data through the same validation and sanitization logic. Used `sanitizeText` (DOMPurify) on federated content before storage.

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -10,6 +10,7 @@ import {
 	getBaseUrl,
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
+import { sanitizeText } from './lib/sanitization.js'
 import { safeFetch } from './lib/ssrfProtection.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
@@ -506,13 +507,19 @@ function extractEventProperties(event: ActivityPubEvent | Record<string, unknown
 
 	const getString = (val: unknown) => (typeof val === 'string' ? val : null)
 	const getNumber = (val: unknown) => (typeof val === 'number' ? val : null)
+	const getSanitizedString = (val: unknown) => {
+		const str = getString(val)
+		return str ? sanitizeText(str) : null
+	}
+
+	const locationVal = getLocationValue(eventObj.location)
 
 	return {
 		eventId: getString(eventObj.id) || '',
-		eventName: getString(eventObj.name) || '',
-		eventSummary: getString(eventObj.summary),
-		eventContent: getString(eventObj.content),
-		locationValue: getLocationValue(eventObj.location),
+		eventName: sanitizeText(getString(eventObj.name) || ''),
+		eventSummary: getSanitizedString(eventObj.summary),
+		eventContent: getSanitizedString(eventObj.content),
+		locationValue: locationVal ? sanitizeText(locationVal) : null,
 		eventStartTime: getString(eventObj.startTime) || '',
 		eventEndTime: getString(eventObj.endTime),
 		eventDuration: getString(eventObj.duration),
@@ -786,7 +793,8 @@ async function handleCreateNote(
 	if (!inReplyTo) return
 
 	const noteId = typeof noteObj.id === 'string' ? noteObj.id : ''
-	const noteContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const rawContent = typeof noteObj.content === 'string' ? noteObj.content : ''
+	const noteContent = sanitizeText(rawContent)
 
 	// Check if it's replying to an event
 	const event = await prisma.event.findFirst({
@@ -893,8 +901,10 @@ async function handleUpdate(activity: UpdateActivity): Promise<void> {
 async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknown>): Promise<void> {
 	const eventObj = event as Record<string, unknown>
 	const eventId = typeof eventObj.id === 'string' ? eventObj.id : ''
-	const eventName = typeof eventObj.name === 'string' ? eventObj.name : ''
-	const eventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const rawEventName = typeof eventObj.name === 'string' ? eventObj.name : ''
+	const eventName = sanitizeText(rawEventName)
+	const rawEventSummary = typeof eventObj.summary === 'string' ? eventObj.summary : null
+	const eventSummary = rawEventSummary ? sanitizeText(rawEventSummary) : null
 	const eventStartTime = typeof eventObj.startTime === 'string' ? eventObj.startTime : ''
 	const eventEndTime = typeof eventObj.endTime === 'string' ? eventObj.endTime : null
 	const eventStatus = eventObj.eventStatus
@@ -911,6 +921,10 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 		locationValue = eventLocation.name
 	} else {
 		locationValue = null
+	}
+
+	if (locationValue) {
+		locationValue = sanitizeText(locationValue)
 	}
 
 	await prisma.event.updateMany({
@@ -945,8 +959,8 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 async function handleUpdatePerson(person: Person | Record<string, unknown>): Promise<void> {
 	const personObj = person as Person
 	const personId = personObj.id
-	const personName = personObj.name || undefined
-	const personSummary = personObj.summary || undefined
+	const personName = personObj.name ? sanitizeText(personObj.name) : undefined
+	const personSummary = personObj.summary ? sanitizeText(personObj.summary) : undefined
 	const personDisplayColor = personObj.displayColor || undefined
 	const personIconUrl = personObj.icon?.url || undefined
 	const personImageUrl = personObj.image?.url || undefined

--- a/src/tests/federation.test.ts
+++ b/src/tests/federation.test.ts
@@ -2355,5 +2355,87 @@ describe('Federation Handlers', () => {
 				expect(follower?.accepted).toBe(true)
 			})
 		})
+
+	describe('Input Sanitization', () => {
+		it('should sanitize HTML from Create activity (Events)', async () => {
+			const remoteActor = {
+				id: 'https://example.com/users/hacker',
+				type: 'Person',
+				preferredUsername: 'hacker',
+			}
+
+			vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+			vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue({
+				id: 'remote-hacker-id',
+				username: 'hacker@example.com',
+			} as any)
+
+			const activity = {
+				id: 'https://example.com/activities/create-xss',
+				type: ActivityType.CREATE,
+				actor: remoteActor.id,
+				object: {
+					type: ObjectType.EVENT,
+					id: 'https://example.com/events/xss-event',
+					name: '<script>alert(1)</script>Safe Title',
+					summary: '<b>Bold Summary</b>',
+					content: '<img src=x onerror=alert(1)>Content',
+					startTime: new Date().toISOString(),
+				},
+			}
+
+			await handleActivity(activity as any)
+
+			const event = await prisma.event.findFirst({
+				where: { externalId: activity.object.id },
+			})
+
+			expect(event).toBeTruthy()
+			expect(event?.title).toBe('Safe Title') // Script tag stripped
+			expect(event?.summary).toBe('Bold Summary') // HTML tags stripped
+		})
+
+		it('should sanitize HTML from Create Note activity (Comments)', async () => {
+			const remoteActor = {
+				id: 'https://example.com/users/hacker',
+				type: 'Person',
+				preferredUsername: 'hacker',
+			}
+
+			const remoteUser = await prisma.user.create({
+				data: {
+					username: 'hacker@example.com',
+					email: 'hacker@example.com',
+					name: 'Hacker',
+					isRemote: true,
+					externalActorUrl: remoteActor.id,
+				},
+			})
+
+			vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+			vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+			const activity = {
+				id: 'https://example.com/activities/create-comment-xss',
+				type: ActivityType.CREATE,
+				actor: remoteActor.id,
+				object: {
+					type: ObjectType.NOTE,
+					id: 'https://example.com/comments/xss',
+					content: '<a href="javascript:alert(1)">Click me</a>',
+					inReplyTo: `${baseUrl}/events/${testEvent.id}`,
+				},
+			}
+
+			await handleActivity(activity as any)
+
+			const comment = await prisma.comment.findFirst({
+				where: { externalId: activity.object.id },
+			})
+
+			expect(comment).toBeTruthy()
+			expect(comment?.content).toBe('Click me') // Anchor tag stripped
+		})
+	})
 	})
 })


### PR DESCRIPTION
**Vulnerability:** Federated content (ActivityPub events and notes) was stored in the database without sanitization, allowing potential Stored XSS if malicious HTML was injected by remote instances.

**Fix:**
- Updated `src/federation.ts` to use `sanitizeText` (DOMPurify) on incoming text fields:
    - `eventName`, `eventSummary`, `eventContent`, `locationValue` in `extractEventProperties` (used for Create/Update events).
    - `eventName`, `eventSummary`, `locationValue` in `handleUpdateEvent`.
    - `personName`, `personSummary` in `handleUpdatePerson`.
    - `noteContent` in `handleCreateNote`.
- Added regression tests in `src/tests/federation.test.ts` to verify that HTML tags are stripped from federated Create activities for Events and Notes.

**Verification:**
- Ran `npm test src/tests/federation.test.ts` (all passed).
- Ran `npm run build:server` (passed).


---
*PR created automatically by Jules for task [11360527837412405146](https://jules.google.com/task/11360527837412405146) started by @burnoutberni*