### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing in rate limiting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal 🛡️
+
+## 2025-02-18 - [IP Spoofing in Rate Limiting]
+**Vulnerability:** The rate limiting middleware was determining the client IP by taking the *first* address in the `X-Forwarded-For` header (`split(',')[0]`). In many proxy configurations (standard appending behavior), the client controls the beginning of the header, allowing them to spoof their IP and bypass rate limits.
+**Learning:** Relying on `X-Forwarded-For` without validating the trusted proxy chain is dangerous. In a containerized environment with a known reverse proxy (like Caddy), we should prioritize `X-Real-IP` (if set by the proxy) or use the *last* IP in `X-Forwarded-For` (which represents the connection to our proxy).
+**Prevention:** Always use the *last* trusted IP in `X-Forwarded-For`, or prefer `X-Real-IP` if the infrastructure guarantees its authenticity. Avoid `split(',')[0]` on `X-Forwarded-For`.

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -85,8 +85,15 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 	return async (c: Context, next: Next) => {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
+
+		// Security: Prefer X-Real-IP if set (by trusted proxy like Caddy)
+		// Otherwise use the LAST IP in X-Forwarded-For (the one that connected to our proxy)
+		// Taking the first IP allows spoofing: "X-Forwarded-For: spoofed, real" -> "spoofed"
+		const forwardedFor = c.req.header('x-forwarded-for')
 		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+			c.req.header('x-real-ip') ||
+			(forwardedFor ? forwardedFor.split(',').pop()?.trim() : undefined) ||
+			'unknown'
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.security.test.ts
+++ b/src/tests/middleware/rateLimit.security.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { rateLimit } from '../../middleware/rateLimit.js'
+import { Context } from 'hono'
+import { randomBytes } from 'crypto'
+
+// Create a minimal mock context
+function createMockContext(headers: Record<string, string>): Context {
+    const resHeaders: Record<string, string> = {}
+    return {
+        req: {
+            header: (name: string) => headers[name.toLowerCase()],
+        },
+        res: {
+            status: 200,
+        },
+        header: (name: string, value: string) => {
+            resHeaders[name] = value
+        },
+        get: (key: string) => undefined, // No user
+        set: () => {},
+        resHeaders,
+    } as unknown as Context
+}
+
+function getRandomIp() {
+    return `10.${randomBytes(1)[0]}.${randomBytes(1)[0]}.${randomBytes(1)[0]}`
+}
+
+describe('Rate Limiting Middleware - IP Security', () => {
+    let next: any
+
+    beforeEach(() => {
+        next = vi.fn()
+    })
+
+    it('should prevent IP spoofing: rate limits based on real IP (last in X-Forwarded-For)', async () => {
+        const middleware = rateLimit({
+            windowMs: 1000,
+            maxRequests: 5,
+        })
+
+        const realIp = getRandomIp()
+        const spoofedIp1 = getRandomIp()
+        const spoofedIp2 = getRandomIp()
+
+        // 1. Send 5 requests from spoofedIp1
+        for (let i = 0; i < 5; i++) {
+            const ctx = createMockContext({
+                'x-forwarded-for': `${spoofedIp1}, ${realIp}`
+            })
+            await middleware(ctx, next)
+        }
+
+        // 2. Send 1 more request from spoofedIp1 - should be blocked
+        // Because realIp is now exhausted
+        const ctxBlocked = createMockContext({
+            'x-forwarded-for': `${spoofedIp1}, ${realIp}`
+        })
+        try {
+            await middleware(ctxBlocked, next)
+        } catch (e: any) {
+            expect(e.message).toContain('Rate limit exceeded')
+        }
+
+        // 3. Send 1 request from spoofedIp2 (same real IP) - should ALSO be blocked
+        // If vulnerable, this would pass as a "new user" (spoofedIp2)
+        // If secure, this uses realIp which is already exhausted
+        const ctxNewSpoof = createMockContext({
+            'x-forwarded-for': `${spoofedIp2}, ${realIp}`
+        })
+
+        let errorThrown = false
+        try {
+            await middleware(ctxNewSpoof, next)
+        } catch (e: any) {
+            errorThrown = true
+            expect(e.message).toContain('Rate limit exceeded')
+        }
+
+        expect(errorThrown).toBe(true)
+    })
+
+    it('should prioritize X-Real-IP if present', async () => {
+        const middleware = rateLimit({
+            windowMs: 1000,
+            maxRequests: 5,
+        })
+
+        const realIp = getRandomIp()
+        const xffIp = getRandomIp() // Should be ignored in favor of X-Real-IP
+
+        // 1. Send 5 requests from realIp
+        for (let i = 0; i < 5; i++) {
+            const ctx = createMockContext({
+                'x-real-ip': realIp,
+                'x-forwarded-for': xffIp
+            })
+            await middleware(ctx, next)
+        }
+
+        // 2. Send 1 request from DIFFERENT xffIp but SAME X-Real-IP
+        const ctxBlocked = createMockContext({
+            'x-real-ip': realIp,
+            'x-forwarded-for': getRandomIp()
+        })
+
+        let errorThrown = false
+        try {
+            await middleware(ctxBlocked, next)
+        } catch (e: any) {
+            errorThrown = true
+            expect(e.message).toContain('Rate limit exceeded')
+        }
+
+        expect(errorThrown).toBe(true)
+    })
+})


### PR DESCRIPTION
🛡️ Sentinel Security Fix

**Vulnerability:**
The rate limiting middleware was vulnerable to IP spoofing because it trusted the first IP address in the `X-Forwarded-For` header. Malicious actors could forge this header (e.g., `X-Forwarded-For: 1.2.3.4`) to bypass rate limits, as the real IP is typically appended to the end of the list by proxies.

**Impact:**
Attackers could bypass rate limits for sensitive endpoints (like login/signup) by rotating the spoofed IP in the header, leading to potential brute force or DoS attacks.

**Fix:**
The middleware now:
1. Prioritizes `X-Real-IP` if set (commonly used by Caddy/Nginx).
2. Falls back to the *last* IP in `X-Forwarded-For`, which represents the IP that connected to the immediate upstream proxy (our trusted infrastructure).

**Verification:**
Added `src/tests/middleware/rateLimit.security.test.ts` which verifies:
- Requests with spoofed `X-Forwarded-For` headers are correctly attributed to the real IP.
- `X-Real-IP` takes precedence when provided.
- Existing tests passed.

---
*PR created automatically by Jules for task [12064588590398116299](https://jules.google.com/task/12064588590398116299) started by @burnoutberni*