### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2025-02-14 - Insecure IP Extraction in Rate Limiting
+**Vulnerability:** The rate limiting middleware blindly trusted the first IP in the `X-Forwarded-For` header (`split(',')[0]`). This allowed attackers to bypass rate limits by spoofing the header (e.g., `X-Forwarded-For: spoofed-ip`).
+**Learning:** Middleware often defaults to `X-Forwarded-For` without validating the proxy trust chain. When using reverse proxies (like Caddy), `X-Real-IP` is often more reliable, or the *last* IP in `X-Forwarded-For` (the one the proxy observed) should be used if the proxy appends to it.
+**Prevention:** Prioritize `X-Real-IP` (if set by trusted proxy) or use the last IP in `X-Forwarded-For`. Avoid using the first IP unless the entire proxy chain is trusted and validated.

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -86,7 +86,9 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
 		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+			c.req.header('x-real-ip') ||
+			c.req.header('x-forwarded-for')?.split(',').pop()?.trim() ||
+			'unknown'
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.security.test.ts
+++ b/src/tests/middleware/rateLimit.security.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Context } from 'hono'
+import { rateLimit } from '../../middleware/rateLimit.js'
+
+describe('Rate Limiting Security', () => {
+  let mockContext: Context
+  let mockNext: () => Promise<void>
+  let mockRequest: any
+
+  let testCounter = 0
+
+  beforeEach(() => {
+    testCounter++
+    mockNext = vi.fn().mockResolvedValue(undefined)
+    mockRequest = {
+      header: vi.fn(),
+    }
+    mockContext = {
+      req: mockRequest,
+      get: vi.fn(),
+      header: vi.fn(),
+      res: {
+        status: 200,
+      },
+    } as unknown as Context
+  })
+
+  it('should prevent IP spoofing via X-Forwarded-For header', async () => {
+    // Set limit to 1 request
+    const middleware = rateLimit({ windowMs: 1000, maxRequests: 1 })
+
+    const spoofedIp = `1.2.3.${testCounter}`
+    const realIp1 = `10.0.${testCounter}.1`
+    const realIp2 = `10.0.${testCounter}.2`
+
+    // Request 1: Attacker sends spoofed IP, proxy appends real IP 1
+    mockRequest.header.mockImplementation((name: string) => {
+      if (name === 'x-forwarded-for') return `${spoofedIp}, ${realIp1}`
+      return undefined
+    })
+
+    // First request should succeed
+    await middleware(mockContext, mockNext)
+    expect(mockNext).toHaveBeenCalledTimes(1)
+
+    // Request 2: Different real user (or same attacker from different IP) sends same spoofed IP
+    // If the rate limiter uses the first IP (spoofed), this will be blocked.
+    // If it uses the last IP (real), this is a different user, so it should succeed.
+    mockRequest.header.mockImplementation((name: string) => {
+        if (name === 'x-forwarded-for') return `${spoofedIp}, ${realIp2}`
+        return undefined
+    })
+
+    // Reset mocks for second call
+    mockNext = vi.fn().mockResolvedValue(undefined)
+
+    // This should NOT throw if the implementation is secure (using real IP)
+    await middleware(mockContext, mockNext)
+    expect(mockNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('should prioritize X-Real-IP over X-Forwarded-For', async () => {
+    const middleware = rateLimit({ windowMs: 1000, maxRequests: 1 })
+
+    const spoofedForwarded = `1.2.3.${testCounter}`
+    const realIp1 = `10.0.${testCounter}.3`
+    const realIp2 = `10.0.${testCounter}.4`
+
+    // Request 1
+    mockRequest.header.mockImplementation((name: string) => {
+      if (name === 'x-forwarded-for') return spoofedForwarded
+      if (name === 'x-real-ip') return realIp1
+      return undefined
+    })
+
+    await middleware(mockContext, mockNext)
+
+    // Request 2: Different Real IP, same spoofed X-Forwarded-For
+    mockRequest.header.mockImplementation((name: string) => {
+        if (name === 'x-forwarded-for') return spoofedForwarded
+        if (name === 'x-real-ip') return realIp2
+        return undefined
+    })
+
+    mockNext = vi.fn().mockResolvedValue(undefined)
+
+    // Should succeed if X-Real-IP is used
+    await middleware(mockContext, mockNext)
+    expect(mockNext).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The rate limiting middleware was extracting the client IP address by blindly trusting the first element of the `X-Forwarded-For` header. This allowed an attacker to bypass rate limits by spoofing the header (e.g., sending `X-Forwarded-For: fake-ip`).

🎯 Impact: Attackers could bypass rate limits to perform DoS attacks, brute force attempts, or abuse APIs without restriction.

🔧 Fix: Updated `src/middleware/rateLimit.ts` to prioritize `X-Real-IP` (if present) or use the *last* IP in the `X-Forwarded-For` list, which represents the IP observed by the immediate upstream proxy.

✅ Verification: Added a new test file `src/tests/middleware/rateLimit.security.test.ts` which simulates the spoofing attack and confirms that the correct (trusted) IP is used for rate limiting.

---
*PR created automatically by Jules for task [9783423247507181062](https://jules.google.com/task/9783423247507181062) started by @burnoutberni*