### PR TITLE
Palette: Add clear button to search bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Interactive Input Icons
+**Learning:** The `Input` component's `rightIcon` container has `pointer-events-none` by default, preventing interaction with buttons (like clear or toggle password).
+**Action:** Use the new `rightIconInteractive` prop when adding clickable elements to inputs to ensure accessibility and functionality.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -172,11 +172,28 @@ export function SearchBar() {
 		}
 	}
 
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	const selectableItems = getSelectableItems()
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<button
+			onClick={handleClear}
+			className="p-1 hover:bg-neutral-100 rounded-full dark:hover:bg-neutral-800 text-text-tertiary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+			aria-label="Clear search"
+			type="button">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +206,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={!isLoading && Boolean(query)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchBar } from '../../components/SearchBar'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../../design-system'
+
+// Mock api
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('SearchBar', () => {
+  it('renders correctly', () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <SearchBar />
+        </MemoryRouter>
+      </ThemeProvider>
+    )
+    expect(screen.getByPlaceholderText(/search events, users/i)).toBeInTheDocument()
+  })
+
+  it('shows clear button when text is entered and clears it on click', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <SearchBar />
+        </MemoryRouter>
+      </ThemeProvider>
+    )
+
+    const input = screen.getByPlaceholderText(/search events, users/i)
+    await user.type(input, 'test query')
+
+    expect(input).toHaveValue('test query')
+
+    // Check for clear button
+    // We need to wait for the debounce and API call to finish so loading state is false
+    const clearButton = await screen.findByRole('button', { name: /clear search/i }, { timeout: 1000 })
+    expect(clearButton).toBeInTheDocument()
+
+    // Click clear
+    await user.click(clearButton)
+
+    expect(input).toHaveValue('')
+    expect(input).toHaveFocus()
+
+    // Clear button should disappear
+    expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Added a clear 'X' button to the search bar to improve UX. This button allows users to quickly clear their search query and refocus the input field. The implementation includes modifying the `Input` component to support interactive icons and adding unit tests.

---
*PR created automatically by Jules for task [10660005632409005291](https://jules.google.com/task/10660005632409005291) started by @burnoutberni*