### PR TITLE
🛡️ Sentinel: [HIGH] Fix ActivityPub Digest verification bypass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,7 +1115,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1132,7 +1131,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1149,7 +1147,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1166,7 +1163,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1183,7 +1179,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1200,7 +1195,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1217,7 +1211,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1234,7 +1227,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1251,7 +1243,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1268,7 +1259,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1285,7 +1275,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1302,7 +1291,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1319,7 +1307,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1336,7 +1323,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1353,7 +1339,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1370,7 +1355,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1387,7 +1371,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1404,7 +1387,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1421,7 +1403,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1438,7 +1419,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1455,7 +1435,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1472,7 +1451,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1489,7 +1467,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1506,7 +1483,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1523,7 +1499,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1540,7 +1515,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2706,7 +2680,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2720,7 +2693,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2734,7 +2706,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2748,7 +2719,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2762,7 +2732,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2776,7 +2745,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2790,7 +2758,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2804,7 +2771,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2818,7 +2784,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2832,7 +2797,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2846,7 +2810,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2860,7 +2823,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2874,7 +2836,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2888,7 +2849,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2902,7 +2862,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2916,7 +2875,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2930,7 +2888,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2944,7 +2901,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2958,7 +2914,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2972,7 +2927,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2986,7 +2940,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3000,7 +2953,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3760,7 +3712,7 @@
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
 			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5503,7 +5455,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5535,7 +5486,7 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
 			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -6947,7 +6898,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7417,7 +7368,7 @@
 			"version": "4.21.0",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.27.0",
@@ -7503,7 +7454,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -11,7 +11,7 @@ import {
 	createOrderedCollectionPage,
 } from './lib/activitypubHelpers.js'
 import { canViewPrivateProfile } from './lib/privacy.js'
-import { verifySignature } from './lib/httpSignature.js'
+import { verifySignature, createDigest } from './lib/httpSignature.js'
 import { ActivitySchema, PersonSchema, EventSchema } from './lib/activitypubSchemas.js'
 import {
 	ACTIVITYPUB_CONTEXTS,
@@ -563,10 +563,31 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read raw body for digest verification
+			let rawBody: string
+			try {
+				rawBody = await c.req.text()
+			} catch (error) {
+				logger.error('[Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify Digest header if present
+			// This prevents replay attacks where a valid signature (covering the digest)
+			// is reused with a different body that doesn't match the digest.
+			const digestHeader = c.req.header('digest')
+			if (digestHeader) {
+				const calculatedDigest = await createDigest(rawBody)
+				if (digestHeader !== calculatedDigest) {
+					logger.error('[Inbox] Digest mismatch')
+					return c.json({ error: 'Digest mismatch' }, 401)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(rawBody) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {
@@ -656,10 +677,31 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read raw body for digest verification
+			let rawBody: string
+			try {
+				rawBody = await c.req.text()
+			} catch (error) {
+				logger.error('[Shared Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify Digest header if present
+			// This prevents replay attacks where a valid signature (covering the digest)
+			// is reused with a different body that doesn't match the digest.
+			const digestHeader = c.req.header('digest')
+			if (digestHeader) {
+				const calculatedDigest = await createDigest(rawBody)
+				if (digestHeader !== calculatedDigest) {
+					logger.error('[Shared Inbox] Digest mismatch')
+					return c.json({ error: 'Digest mismatch' }, 401)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(rawBody) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {

--- a/src/tests/digest-verification.test.ts
+++ b/src/tests/digest-verification.test.ts
@@ -139,4 +139,179 @@ describe('Digest Verification Vulnerability', () => {
 		const body = await res.json()
 		expect(body).toEqual({ error: 'Digest mismatch' })
 	})
+
+	it('should accept a request with a valid signature and valid digest', async () => {
+		const validBody = {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://remote.com/activities/1',
+			type: 'Follow',
+			actor: actorUrl,
+			object: 'http://localhost:3000/users/alice',
+		}
+		const validBodyString = JSON.stringify(validBody)
+
+		// Calculate valid Digest
+		const hash = createHash('sha256').update(validBodyString).digest('base64')
+		const digestHeader = `SHA-256=${hash}`
+
+		// Create headers for signature
+		const date = new Date().toUTCString()
+		const headers = {
+			host: 'localhost:3000',
+			date,
+			digest: digestHeader,
+			'(request-target)': 'post /users/alice/inbox',
+			'content-type': 'application/activity+json',
+		}
+
+		// Sign the request
+		const signature = signRequest(privateKey, keyId, 'POST', '/users/alice/inbox', headers)
+
+		const res = await app.request('/users/alice/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				host: 'localhost:3000',
+				date,
+				digest: digestHeader,
+				signature,
+			},
+			body: validBodyString,
+		})
+
+		expect(res.status).toBe(202)
+		const body = await res.json()
+		expect(body).toEqual({ status: 'accepted' })
+	})
+
+	it('should accept a request with a valid signature and no digest header (backward compatibility)', async () => {
+		const validBody = {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://remote.com/activities/1',
+			type: 'Follow',
+			actor: actorUrl,
+			object: 'http://localhost:3000/users/alice',
+		}
+		const validBodyString = JSON.stringify(validBody)
+
+		// Create headers for signature (NO DIGEST)
+		const date = new Date().toUTCString()
+		const headers = {
+			host: 'localhost:3000',
+			date,
+			'(request-target)': 'post /users/alice/inbox',
+			'content-type': 'application/activity+json',
+		}
+
+		// Sign the request
+		const signature = signRequest(privateKey, keyId, 'POST', '/users/alice/inbox', headers)
+
+		const res = await app.request('/users/alice/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				host: 'localhost:3000',
+				date,
+				signature,
+			},
+			body: validBodyString,
+		})
+
+		expect(res.status).toBe(202)
+		const body = await res.json()
+		expect(body).toEqual({ status: 'accepted' })
+	})
+
+	describe('Shared Inbox (/inbox)', () => {
+		it('should reject a request with a valid signature but a modified body', async () => {
+			const validBody = {
+				'@context': 'https://www.w3.org/ns/activitystreams',
+				id: 'https://remote.com/activities/shared/1',
+				type: 'Follow',
+				actor: actorUrl,
+				object: 'http://localhost:3000/users/alice',
+			}
+			const validBodyString = JSON.stringify(validBody)
+
+			const hash = createHash('sha256').update(validBodyString).digest('base64')
+			const digestHeader = `SHA-256=${hash}`
+
+			const date = new Date().toUTCString()
+			const headers = {
+				host: 'localhost:3000',
+				date,
+				digest: digestHeader,
+				'(request-target)': 'post /inbox',
+				'content-type': 'application/activity+json',
+			}
+
+			const signature = signRequest(privateKey, keyId, 'POST', '/inbox', headers)
+
+			const maliciousBody = {
+				...validBody,
+				type: 'Create',
+				object: {
+					type: 'Note',
+					content: 'Malicious shared content',
+				},
+			}
+
+			const res = await app.request('/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					host: 'localhost:3000',
+					date,
+					digest: digestHeader,
+					signature,
+				},
+				body: JSON.stringify(maliciousBody),
+			})
+
+			expect(res.status).toBe(401)
+			const body = await res.json()
+			expect(body).toEqual({ error: 'Digest mismatch' })
+		})
+
+		it('should accept a request with a valid signature and valid digest', async () => {
+			const validBody = {
+				'@context': 'https://www.w3.org/ns/activitystreams',
+				id: 'https://remote.com/activities/shared/1',
+				type: 'Follow',
+				actor: actorUrl,
+				object: 'http://localhost:3000/users/alice',
+			}
+			const validBodyString = JSON.stringify(validBody)
+
+			const hash = createHash('sha256').update(validBodyString).digest('base64')
+			const digestHeader = `SHA-256=${hash}`
+
+			const date = new Date().toUTCString()
+			const headers = {
+				host: 'localhost:3000',
+				date,
+				digest: digestHeader,
+				'(request-target)': 'post /inbox',
+				'content-type': 'application/activity+json',
+			}
+
+			const signature = signRequest(privateKey, keyId, 'POST', '/inbox', headers)
+
+			const res = await app.request('/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					host: 'localhost:3000',
+					date,
+					digest: digestHeader,
+					signature,
+				},
+				body: validBodyString,
+			})
+
+			expect(res.status).toBe(202)
+			const body = await res.json()
+			expect(body).toEqual({ status: 'accepted' })
+		})
+	})
 })

--- a/src/tests/digest-verification.test.ts
+++ b/src/tests/digest-verification.test.ts
@@ -1,0 +1,142 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import activitypubApp from '../activitypub.js'
+import { generateKeyPairSync, createHash } from 'node:crypto'
+import { signRequest } from '../lib/httpSignature.js'
+
+// Mock dependencies
+vi.mock('../lib/prisma.js', () => ({
+	prisma: {
+		user: {
+			findUnique: vi.fn(),
+		},
+	},
+}))
+
+vi.mock('../federation.js', () => ({
+	handleActivity: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock ssrfProtection to return our public key
+vi.mock('../lib/ssrfProtection.js', () => ({
+	safeFetch: vi.fn(),
+	isUrlSafe: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../lib/activitypubHelpers.js', () => ({
+	getBaseUrl: vi.fn(() => 'http://localhost:3000'),
+}))
+
+// Import mocked modules to control them
+import { prisma } from '../lib/prisma.js'
+import { safeFetch } from '../lib/ssrfProtection.js'
+
+describe('Digest Verification Vulnerability', () => {
+	let app: Hono
+	let privateKey: string
+	let publicKey: string
+	const keyId = 'https://remote.com/users/attacker#main-key'
+	const actorUrl = 'https://remote.com/users/attacker'
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		app = new Hono()
+		app.route('/', activitypubApp)
+
+		// Generate keys
+		const keys = generateKeyPairSync('rsa', {
+			modulusLength: 2048,
+			publicKeyEncoding: {
+				type: 'spki',
+				format: 'pem',
+			},
+			privateKeyEncoding: {
+				type: 'pkcs8',
+				format: 'pem',
+			},
+		})
+		privateKey = keys.privateKey
+		publicKey = keys.publicKey
+
+		// Mock local user (alice) exists
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			id: 'user_123',
+			username: 'alice',
+			isRemote: false,
+		} as any)
+
+		// Mock fetching the remote actor's public key
+		vi.mocked(safeFetch).mockImplementation(async (url) => {
+			if (url === actorUrl) {
+				return {
+					ok: true,
+					json: async () => ({
+						publicKey: {
+							publicKeyPem: publicKey,
+						},
+					}),
+				} as Response
+			}
+			return { ok: false } as Response
+		})
+	})
+
+	it('should reject a request with a valid signature but a modified body', async () => {
+		const validBody = {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://remote.com/activities/1',
+			type: 'Follow',
+			actor: actorUrl,
+			object: 'http://localhost:3000/users/alice',
+		}
+		const validBodyString = JSON.stringify(validBody)
+
+		// Calculate valid Digest
+		const hash = createHash('sha256').update(validBodyString).digest('base64')
+		const digestHeader = `SHA-256=${hash}`
+
+		// Create headers for signature
+		const date = new Date().toUTCString()
+		const headers = {
+			host: 'localhost:3000',
+			date,
+			digest: digestHeader,
+			'(request-target)': 'post /users/alice/inbox',
+			'content-type': 'application/activity+json',
+		}
+
+		// Sign the request (using the valid body's digest)
+		const signature = signRequest(privateKey, keyId, 'POST', '/users/alice/inbox', headers)
+
+		// Create MALICIOUS body (different content, same ID/Actor)
+		const maliciousBody = {
+			...validBody,
+			type: 'Create', // Changed type!
+			object: {
+				type: 'Note',
+				content: 'This is a malicious message injected via body swapping!',
+			},
+		}
+
+		// Note: We are sending maliciousBody, but using the signature/digest of validBody
+		// The server should now reject this because the Digest header doesn't match the body.
+
+		const res = await app.request('/users/alice/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				host: 'localhost:3000',
+				date,
+				digest: digestHeader, // Valid digest for the ORIGINAL body
+				signature,
+			},
+			body: JSON.stringify(maliciousBody), // Sending the MALICIOUS body
+		})
+
+		// Should return 401 Unauthorized (Digest mismatch)
+		expect(res.status).toBe(401)
+		const body = await res.json()
+		expect(body).toEqual({ error: 'Digest mismatch' })
+	})
+})


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix ActivityPub Digest Verification Bypass

🚨 Severity: HIGH
💡 Vulnerability: The ActivityPub inbox endpoints verified the HTTP signature (which typically includes the `Digest` header in the signed headers) but failed to verify that the `Digest` header actually matched the SHA-256 hash of the request body. This allowed an attacker to replay a valid signature with a modified body, as long as they kept the original `Digest` header.
🎯 Impact: An attacker could impersonate a legitimate actor by capturing a signed request and resending it with a malicious payload (e.g., swapping a harmless object for a malicious one), potentially bypassing authorization or injecting false data.
🔧 Fix: Modified `src/activitypub.ts` to read the raw request body, calculate its digest, and strictly compare it against the provided `Digest` header before parsing the JSON payload.
✅ Verification: Added `src/tests/digest-verification.test.ts` which reproduces the attack scenario and asserts that the server now rejects the request with a 401 Unauthorized error. Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [13101269093206532050](https://jules.google.com/task/13101269093206532050) started by @burnoutberni*