### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -172,11 +172,26 @@ export function SearchBar() {
 		}
 	}
 
+	const handleClear = () => {
+		setQuery('')
+		inputRef.current?.focus()
+	}
+
 	const selectableItems = getSelectableItems()
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
 	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const clearButton =
+		query && !isLoading ? (
+			<button
+				type="button"
+				onClick={handleClear}
+				className="p-1 rounded-full text-text-tertiary hover:text-text-primary hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+				aria-label="Clear search">
+				<CloseIcon className="w-4 h-4" />
+			</button>
+		) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -188,8 +203,10 @@ export function SearchBar() {
 				onKeyDown={handleKeyDown}
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
+				aria-label="Search"
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={loadingSpinner || clearButton}
+				rightIconInteractive={Boolean(clearButton)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Navbar.test.tsx
+++ b/client/src/tests/components/Navbar.test.tsx
@@ -210,7 +210,7 @@ describe('Navbar Component', () => {
 		render(<Navbar />, { wrapper })
 
 		// Search button should be visible on mobile (lg:hidden)
-		const searchButton = screen.getByLabelText('Search')
+		const searchButton = screen.getByRole('button', { name: 'Search' })
 		expect(searchButton).toBeInTheDocument()
 	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper, clearQueryClient } from '../testUtils'
+import { api } from '@/lib/api-client'
+
+// Mock API
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar', () => {
+	const { wrapper, queryClient } = createTestWrapper()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+        // Mock successful response to avoid errors in component
+        const mockResults = { users: [], events: [], remoteAccountSuggestion: null }
+        vi.mocked(api.get).mockResolvedValue(mockResults)
+	})
+
+	afterEach(() => {
+		clearQueryClient(queryClient)
+	})
+
+	it('renders with accessibility label', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox', { name: /search/i })
+		expect(input).toBeInTheDocument()
+	})
+
+	it('shows clear button when text is entered', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox', { name: /search/i })
+
+		// Initially no clear button
+		expect(screen.queryByLabelText(/clear search/i)).not.toBeInTheDocument()
+
+		// Type text
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		// Check clear button appears after debounce/loading
+        await waitFor(() => {
+		    expect(screen.getByLabelText(/clear search/i)).toBeInTheDocument()
+        })
+	})
+
+	it('clears input and focuses when clear button is clicked', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByRole('textbox', { name: /search/i })
+
+		// Type text
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		// Wait for clear button
+        await waitFor(() => {
+            expect(screen.getByLabelText(/clear search/i)).toBeInTheDocument()
+        })
+
+        const clearButton = screen.getByLabelText(/clear search/i)
+
+		// Click clear
+		fireEvent.click(clearButton)
+
+		// Check input is empty
+		expect(input).toHaveValue('')
+
+		// Check input is focused
+		expect(input).toHaveFocus()
+	})
+})


### PR DESCRIPTION
💡 What: Added a clear button (X icon) to the search bar that appears when there is text input.
🎯 Why: To allow users to easily clear their search query without repeatedly pressing backspace.
♿ Accessibility:
- Added `aria-label="Search"` to the input.
- Added `aria-label="Clear search"` to the clear button.
- Ensured focus returns to the input after clearing.

---
*PR created automatically by Jules for task [12852073286483493200](https://jules.google.com/task/12852073286483493200) started by @burnoutberni*