### PR TITLE
🛡️ Sentinel: Fix IP Spoofing in Rate Limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-02-18 - IP Spoofing via X-Forwarded-For Header
+**Vulnerability:** The rate limiting middleware was extracting the client IP address by taking the *first* IP in the `X-Forwarded-For` header (`split(',')[0]`). This allowed attackers to bypass rate limits by spoofing the header (e.g., sending `X-Forwarded-For: <fake-ip>`), as the trusted proxy (Caddy) would append the real IP to the end of the list, resulting in `<fake-ip>, <real-ip>`.
+**Learning:** Even when using a trusted proxy like Caddy which is configured to set headers, application code must still be robust against potential upstream configurations or misconfigurations where headers are appended rather than replaced. The standard security practice when behind a proxy that appends IPs is to trust the *last* IP in the list.
+**Prevention:** Always use the rightmost IP in the `X-Forwarded-For` list when the application is behind a proxy that appends the client IP. Validate and sanitize header inputs. Use dedicated libraries or robust logic for IP extraction rather than naive string splitting.

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -85,8 +85,13 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 	return async (c: Context, next: Next) => {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
-		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+
+		// Securely determine IP address
+		// Trust the last IP in X-Forwarded-For as it's appended by the trusted proxy (Caddy)
+		// This prevents IP spoofing where an attacker sends a fake X-Forwarded-For header
+		const forwardedFor = c.req.header('x-forwarded-for')
+		const ips = forwardedFor ? forwardedFor.split(',') : []
+		const ip = ips.length > 0 ? ips[ips.length - 1].trim() : (c.req.header('x-real-ip') || 'unknown')
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.security.test.ts
+++ b/src/tests/middleware/rateLimit.security.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Context } from 'hono'
+import { rateLimit } from '../../middleware/rateLimit.js'
+import { Errors } from '../../lib/errors.js'
+
+describe('Rate Limiting Security', () => {
+	let mockContext: Context
+	let mockNext: () => Promise<void>
+	let mockRequest: any
+	let realIp: string
+	let spoofedIp: string
+
+	beforeEach(() => {
+		realIp = '203.0.113.1' // Example real IP
+		spoofedIp = '198.51.100.1' // Example spoofed IP
+		mockNext = vi.fn().mockResolvedValue(undefined)
+
+		mockRequest = {
+			header: vi.fn(),
+		}
+
+		mockContext = {
+			req: mockRequest,
+			get: vi.fn(), // No user ID
+			header: vi.fn(),
+			res: {
+				status: 200,
+			},
+		} as unknown as Context
+	})
+
+	it('SECURITY: uses last IP in X-Forwarded-For (trusted proxy appended IP) to prevent spoofing', async () => {
+		// Set a low limit
+		const middleware = rateLimit({ windowMs: 1000, maxRequests: 1 })
+
+		// Request 1: Spoofed IP 1
+		mockRequest.header.mockImplementation((name: string) => {
+			if (name === 'x-forwarded-for') return `${spoofedIp}, ${realIp}`
+			return undefined
+		})
+
+		await middleware(mockContext, mockNext)
+		expect(mockNext).toHaveBeenCalledTimes(1)
+
+		// Request 2: Different Spoofed IP, SAME Real IP
+		// If insecure, this will be counted as a new user and allowed
+		// If secure (using real IP), this should be blocked
+		const spoofedIp2 = '198.51.100.2'
+		mockRequest.header.mockImplementation((name: string) => {
+			if (name === 'x-forwarded-for') return `${spoofedIp2}, ${realIp}`
+			return undefined
+		})
+
+		// This should be blocked because the real IP is the same
+		await expect(middleware(mockContext, mockNext)).rejects.toThrow()
+
+		expect(mockNext).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/tests/middleware/rateLimit.test.ts
+++ b/src/tests/middleware/rateLimit.test.ts
@@ -166,7 +166,8 @@ describe('Rate Limiting Middleware', () => {
 			const middleware = rateLimit({ windowMs: 1000, maxRequests: 5 })
 
 			mockRequest.header.mockImplementation((name: string) => {
-				if (name === 'x-forwarded-for') return `${uniqueIp}, 10.0.0.1`
+				// Use uniqueIp as the last IP (trusted) to avoid test interference
+				if (name === 'x-forwarded-for') return `10.0.0.1, ${uniqueIp}`
 				return undefined
 			})
 			mockContext.get = vi.fn().mockReturnValue(undefined)


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix IP Spoofing in Rate Limiter

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The rate limiter was using the *first* IP in the `X-Forwarded-For` header (`split(',')[0]`). This allowed attackers to bypass rate limits by sending a request with `X-Forwarded-For: <fake-ip>`. The trusted proxy (Caddy) appends the real IP to the end, resulting in `<fake-ip>, <real-ip>`, causing the app to rate limit the fake IP.
🎯 **Impact:** An attacker could bypass rate limits to perform brute-force attacks, DDoS, or scrapers by rotating the spoofed IP in the header.
🔧 **Fix:** Changed the logic to use the *last* IP in the `X-Forwarded-For` list (`split(',').pop()`), which is the IP added by the trusted proxy.
✅ **Verification:** Added `src/tests/middleware/rateLimit.security.test.ts` which confirms that requests with different spoofed IPs but the same real IP are correctly rate-limited together. Existing tests pass.

---
*PR created automatically by Jules for task [220138708812483593](https://jules.google.com/task/220138708812483593) started by @burnoutberni*