### PR TITLE
feat(ui): add clear button to search bar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -134,6 +134,7 @@ export function SearchBar() {
 			// item.type must be 'remote' at this point
 			const suggestion = item.data as RemoteAccountSuggestion
 			resolveRemoteAccount(suggestion.handle)
+			return
 		}
 		setQuery('')
 		setIsOpen(false)

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -38,6 +38,7 @@ export function SearchBar() {
 		if (!query.trim()) {
 			setResults(null)
 			setIsOpen(false)
+			setIsLoading(false)
 			return
 		}
 
@@ -174,9 +175,27 @@ export function SearchBar() {
 
 	const selectableItems = getSelectableItems()
 
-	const searchIcon = <SearchIcon className="w-5 h-5" />
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const leftIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" className="w-5 h-5" />
+	) : (
+		<SearchIcon className="w-5 h-5" />
+	)
+
+	const rightIcon = query ? (
+		<button
+			type="button"
+			onClick={handleClear}
+			className="p-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-full transition-colors"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4 text-text-tertiary" />
+		</button>
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -188,8 +207,9 @@ export function SearchBar() {
 				onKeyDown={handleKeyDown}
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
-				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				leftIcon={leftIcon}
+				rightIcon={rightIcon}
+				rightIconInteractive={Boolean(query)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -73,6 +73,25 @@ describe('Input Component', () => {
 		expect(input).toBeInTheDocument()
 	})
 
+	it('should allow interaction with right icon when rightIconInteractive is true', () => {
+		const handleIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={
+					<button data-testid="right-icon-btn" onClick={handleIconClick}>
+						Clear
+					</button>
+				}
+				rightIconInteractive
+			/>
+		)
+
+		const iconButton = screen.getByTestId('right-icon-btn')
+		fireEvent.click(iconButton)
+		expect(handleIconClick).toHaveBeenCalledTimes(1)
+	})
+
 	it('should handle value changes', () => {
 		const handleChange = vi.fn()
 		render(<Input type="text" onChange={handleChange} />)

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { SearchBar } from '../../components/SearchBar'
 import { createTestWrapper } from '../testUtils'
+import { api } from '@/lib/api-client'
+import type { Mock } from 'vitest'
 
 // Mock api
 vi.mock('@/lib/api-client', () => ({
@@ -17,6 +19,16 @@ vi.mock('@/design-system', async () => {
     return {
         ...actual,
         useThemeColors: vi.fn(() => ({ info: { 500: '#3b82f6' } })),
+    }
+})
+
+// Mock navigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom')
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
     }
 })
 
@@ -55,16 +67,307 @@ describe('SearchBar', () => {
 		expect(input).toHaveFocus()
 	})
 
-    it('should show loading spinner on the left immediately upon typing', () => {
+    it('should show loading spinner on the left immediately upon typing', async () => {
         render(<SearchBar />, { wrapper })
         const input = screen.getByPlaceholderText(/search events, users/i)
 
         fireEvent.change(input, { target: { value: 'test' } })
 
         // Spinner should appear immediately due to useEffect setting isLoading(true)
-        // Note: Spinner has aria-hidden="true" so we need hidden: true option
-        expect(screen.getByRole('status', { hidden: true })).toBeInTheDocument()
-        // Clear button should also be present
+        await waitFor(() => {
+            expect(screen.getByRole('status', { hidden: true })).toBeInTheDocument()
+        })
         expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+    })
+
+    it('should fetch and display search results including remote user', async () => {
+        const mockResults = {
+            users: [
+                { id: '1', username: 'testuser', name: 'Test User', profileImage: 'http://img.com/1.jpg' },
+                { id: '2', username: 'remoteuser', isRemote: true }
+            ],
+            events: [
+                { id: '1', title: 'Test Event', startTime: new Date().toISOString(), location: 'Test Loc', user: { username: 'host' } }
+            ],
+            remoteAccountSuggestion: null
+        }
+
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+            expect(api.get).toHaveBeenCalledWith('/user-search', { q: 'test', limit: 5 })
+        })
+
+        await waitFor(() => {
+             expect(screen.getByText('Test User')).toBeInTheDocument()
+             expect(screen.getByAltText('Test User')).toHaveAttribute('src', 'http://img.com/1.jpg')
+
+             // Check remote user
+             expect(screen.getByText('remoteuser')).toBeInTheDocument()
+             expect(screen.getByText('Remote')).toBeInTheDocument()
+        })
+    })
+
+    it('should handle search error gracefully', async () => {
+        ;(api.get as Mock).mockRejectedValue(new Error('Search failed'))
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'error' } })
+
+        await waitFor(() => {
+            expect(api.get).toHaveBeenCalled()
+        })
+
+        expect(screen.queryByRole('status', { hidden: true })).not.toBeInTheDocument()
+
+        consoleSpy.mockRestore()
+    })
+
+    it('should close dropdown when clicking outside', async () => {
+         const mockResults = { users: [], events: [], remoteAccountSuggestion: null }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+             expect(api.get).toHaveBeenCalled()
+        })
+
+        fireEvent.mouseDown(document.body)
+
+        await waitFor(() => {
+             expect(screen.queryByText('No results found')).not.toBeInTheDocument()
+        })
+    })
+
+    it('should resolve remote account successfully', async () => {
+         const mockResults = {
+            users: [],
+            events: [],
+            remoteAccountSuggestion: { handle: 'user@remote.com', username: 'user', domain: 'remote.com' }
+        }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+        ;(api.post as Mock).mockResolvedValue({ user: { id: '2', username: 'user', isRemote: true } })
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: '@user@remote.com' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Lookup remote account')).toBeInTheDocument()
+        })
+
+        const resolveButton = screen.getByText('Lookup remote account').closest('button')
+        if (resolveButton) {
+            fireEvent.click(resolveButton)
+        }
+
+        // Check for loading state text
+        await waitFor(() => {
+            expect(screen.getByText('Resolving...')).toBeInTheDocument()
+        })
+
+        await waitFor(() => {
+             expect(api.post).toHaveBeenCalledWith(
+                 '/user-search/resolve',
+                 { handle: 'user@remote.com' },
+                 undefined,
+                 'Failed to resolve account'
+             )
+        })
+
+        expect(mockNavigate).toHaveBeenCalledWith('/@user')
+    })
+
+    it('should handle remote account resolution error', async () => {
+         const mockResults = {
+            users: [],
+            events: [],
+            remoteAccountSuggestion: { handle: 'user@remote.com', username: 'user', domain: 'remote.com' }
+        }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+        ;(api.post as Mock).mockRejectedValue(new Error('Failed'))
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: '@user@remote.com' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Lookup remote account')).toBeInTheDocument()
+        })
+
+        const resolveButton = screen.getByText('Lookup remote account').closest('button')
+        if (resolveButton) {
+            fireEvent.click(resolveButton)
+        }
+
+        await waitFor(() => {
+             expect(api.post).toHaveBeenCalled()
+        })
+
+        // Should revert to normal state after error (finally block sets resolving to false)
+        await waitFor(() => {
+            expect(screen.getByText('Lookup remote account')).toBeInTheDocument()
+        })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('should navigate to user profile on click', async () => {
+         const mockResults = {
+            users: [{ id: '1', username: 'testuser' }],
+            events: [],
+            remoteAccountSuggestion: null
+        }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('testuser')).toBeInTheDocument()
+        })
+
+        fireEvent.click(screen.getByText('testuser'))
+
+        expect(mockNavigate).toHaveBeenCalledWith('/@testuser')
+    })
+
+    it('should navigate to event page on click', async () => {
+         const mockResults = {
+            users: [],
+            events: [{ id: '100', title: 'Event A', startTime: new Date().toISOString(), user: { username: 'host' } }],
+            remoteAccountSuggestion: null
+        }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'Event' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Event A')).toBeInTheDocument()
+        })
+
+        fireEvent.click(screen.getByText('Event A'))
+        expect(mockNavigate).toHaveBeenCalledWith('/@host/100')
+    })
+
+    it('should handle keyboard navigation limits and multi-item navigation', async () => {
+        const mockResults = {
+            users: [{ id: '1', username: 'user1' }, { id: '2', username: 'user2' }],
+            events: [],
+            remoteAccountSuggestion: null
+        }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+             expect(screen.getByText('user1')).toBeInTheDocument()
+             expect(screen.getByText('user2')).toBeInTheDocument()
+        })
+
+        // Arrow Up from start (should stay at -1)
+        fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+        // Arrow Down -> Select first item (0)
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+        // Arrow Down -> Select second item (1)
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+        // Arrow Up -> Back to first item (0)
+        fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+        // Arrow Up -> Back to -1
+        fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+        // Enter (at -1) -> Nothing happens
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(mockNavigate).not.toHaveBeenCalled()
+
+        // Arrow Down -> Select first item (0)
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+        // Enter -> Click item (user1)
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        expect(mockNavigate).toHaveBeenCalledWith('/@user1')
+    })
+
+    it('should close on Escape key', async () => {
+        const mockResults = { users: [], events: [], remoteAccountSuggestion: null }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+             expect(screen.queryByText('No results found')).toBeInTheDocument()
+        })
+
+        fireEvent.keyDown(input, { key: 'Escape' })
+
+        expect(screen.queryByText('No results found')).not.toBeInTheDocument()
+        expect(input).not.toHaveFocus()
+    })
+
+    it('should ignore non-navigation keys', async () => {
+        const mockResults = { users: [], events: [], remoteAccountSuggestion: null }
+        ;(api.get as Mock).mockResolvedValue(mockResults)
+
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+        fireEvent.change(input, { target: { value: 'test' } })
+        fireEvent.focus(input)
+
+        await waitFor(() => {
+             expect(screen.queryByText('No results found')).toBeInTheDocument()
+        })
+
+        fireEvent.keyDown(input, { key: 'a' })
+
+        expect(screen.queryByText('No results found')).toBeInTheDocument()
+    })
+
+    it('should return early on keydown if closed', () => {
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        // Is open is false by default
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+        // No error, nothing happens
     })
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Mock api
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+// Mock theme colors
+vi.mock('@/design-system', async () => {
+    const actual = await vi.importActual('@/design-system')
+    return {
+        ...actual,
+        useThemeColors: vi.fn(() => ({ info: { 500: '#3b82f6' } })),
+    }
+})
+
+describe('SearchBar', () => {
+	const { wrapper } = createTestWrapper()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper })
+		expect(screen.getByPlaceholderText(/search events, users/i)).toBeInTheDocument()
+	})
+
+	it('should update query and show clear button', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+		expect(input).toHaveValue('test')
+
+		const clearButton = screen.getByLabelText('Clear search')
+		expect(clearButton).toBeInTheDocument()
+	})
+
+	it('should clear query and focus input when clear button is clicked', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+		const clearButton = screen.getByLabelText('Clear search')
+
+		fireEvent.click(clearButton)
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+	})
+
+    it('should show loading spinner on the left immediately upon typing', () => {
+        render(<SearchBar />, { wrapper })
+        const input = screen.getByPlaceholderText(/search events, users/i)
+
+        fireEvent.change(input, { target: { value: 'test' } })
+
+        // Spinner should appear immediately due to useEffect setting isLoading(true)
+        // Note: Spinner has aria-hidden="true" so we need hidden: true option
+        expect(screen.getByRole('status', { hidden: true })).toBeInTheDocument()
+        // Clear button should also be present
+        expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+    })
+})

--- a/coverage_output.txt
+++ b/coverage_output.txt
@@ -1,0 +1,25 @@
+
+> constellate-client@1.0.0 test:coverage
+> vitest run --coverage --reporter=default src/tests/components/SearchBar.test.tsx
+
+│
+▲  No story files found for the specified pattern: src/**/*.mdx
+
+[1m[46m RUN [49m[22m [36mv4.0.15 [39m[90m/app/client[39m
+      [2mCoverage enabled with [22m[33mv8[39m
+
+ [32m✓[39m [30m[42m unit [49m[39m src/tests/components/SearchBar.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 188[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m4 passed[39m[22m[90m (4)[39m
+[2m   Start at [22m 23:07:57
+[2m   Duration [22m 2.29s[2m (transform 493ms, setup 269ms, import 593ms, tests 188ms, environment 675ms)[22m
+
+[34m % [39m[2mCoverage report from [22m[33mv8[39m
+
+=============================== Coverage summary ===============================
+Statements   : 27.18% ( 146/537 )
+Branches     : 9.54% ( 48/503 )
+Functions    : 17.77% ( 24/135 )
+Lines        : 27.57% ( 142/515 )
+================================================================================


### PR DESCRIPTION
This PR improves the UX of the SearchBar component by adding a clear button when text is entered. It also refines the loading state behavior by moving the spinner to the left side (replacing the search icon) so that the clear button remains accessible while loading or typing. Additionally, it fixes a bug where the loading state would persist if the query was cleared quickly. The `Input` component was updated to support interactive right icons via a new `rightIconInteractive` prop.

---
*PR created automatically by Jules for task [10980548014560386363](https://jules.google.com/task/10980548014560386363) started by @burnoutberni*