### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP Spoofing in Rate Limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-20 - [IP Extraction Vulnerability in Proxy Setup]
+**Vulnerability:** The application was extracting the client IP from the *first* entry in the `X-Forwarded-For` header. This allowed attackers to spoof their IP by sending a request with `X-Forwarded-For: spoofed-ip`.
+**Learning:** Reverse proxies (like Caddy, which is used here) typically *append* the real client IP to the existing `X-Forwarded-For` header. Therefore, the *last* IP in the list is the one added by the trusted proxy and should be considered the true client IP.
+**Prevention:** Always use the last IP address in the `X-Forwarded-For` list when behind a trusted proxy that appends IPs. Configure the proxy to overwrite the header (`header_up X-Forwarded-For {remote_host}`) if possible, but the application logic should default to the last IP for safety.

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -85,8 +85,12 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 	return async (c: Context, next: Next) => {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
+		// Securely get IP: Use the last IP in X-Forwarded-For as it's appended by the trusted proxy
+		// taking the first IP allows spoofing (e.g. "spoofed-ip, real-ip")
 		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+			c.req.header('x-forwarded-for')?.split(',').pop()?.trim() ||
+			c.req.header('x-real-ip') ||
+			'unknown'
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.security.test.ts
+++ b/src/tests/middleware/rateLimit.security.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Context } from 'hono'
+import { rateLimit } from '../../middleware/rateLimit.js'
+import { Errors } from '../../lib/errors.js'
+
+let testCounter = 0
+
+describe('Rate Limiting Security', () => {
+    let mockContext: Context
+    let mockNext: () => Promise<void>
+    let mockRequest: any
+    let realIp: string
+
+    beforeEach(() => {
+        testCounter++
+        realIp = `10.0.0.${testCounter}`
+        mockNext = vi.fn().mockResolvedValue(undefined)
+        mockRequest = {
+            header: vi.fn(),
+        }
+        mockContext = {
+            req: mockRequest,
+            get: vi.fn().mockReturnValue(undefined), // No user ID
+            header: vi.fn(),
+            res: { status: 200 },
+        } as unknown as Context
+    })
+
+    it('should prevent IP spoofing by using the last IP in X-Forwarded-For', async () => {
+        // Set limit to 1 request
+        const middleware = rateLimit({ windowMs: 1000, maxRequests: 1 })
+
+        // Request 1: Attacker sends spoofed IP 1.2.3.4, real IP is appended by proxy
+        // The rate limiter should see the LAST IP (realIp)
+        mockRequest.header.mockImplementation((name: string) => {
+            if (name === 'x-forwarded-for') return `1.2.3.4, ${realIp}`
+            return undefined
+        })
+        await middleware(mockContext, mockNext)
+        expect(mockNext).toHaveBeenCalledTimes(1)
+
+        // Request 2: Attacker changes spoofed IP to 5.6.7.8, real IP remains same
+        // If secure, the rate limiter still sees realIp and blocks the request
+        mockRequest.header.mockImplementation((name: string) => {
+            if (name === 'x-forwarded-for') return `5.6.7.8, ${realIp}`
+            return undefined
+        })
+
+        await expect(middleware(mockContext, mockNext)).rejects.toThrow()
+
+        expect(mockNext).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix IP Spoofing Vulnerability

**Vulnerability:** The rate limiting middleware was extracting the client IP from the *first* entry in the `X-Forwarded-For` header. This allowed attackers to bypass rate limits by sending a request with a spoofed IP in the header (e.g., `X-Forwarded-For: spoofed-ip`). When the request passed through the trusted proxy (Caddy), the real IP was appended, resulting in `spoofed-ip, real-ip`. The application naively used `spoofed-ip`.

**Fix:** Updated `src/middleware/rateLimit.ts` to securely extract the *last* IP address from the `X-Forwarded-For` header. This ensures the IP address used for rate limiting is the one observed and appended by the trusted proxy.

**Verification:**
- Added `src/tests/middleware/rateLimit.security.test.ts` which simulates an IP spoofing attack and verifies that the rate limiter correctly identifies the real IP (the last one) and blocks requests when the limit is exceeded, regardless of the spoofed IP at the start of the list.
- Ran existing tests `src/tests/middleware/rateLimit.test.ts` to ensure no regressions.

**Severity:** HIGH (Allows bypassing rate limits, potential for DoS or brute force attacks)

---
*PR created automatically by Jules for task [7611592840692385849](https://jules.google.com/task/7611592840692385849) started by @burnoutberni*