### PR TITLE
🛡️ Sentinel: [HIGH] Fix ActivityPub Digest Verification Bypass

### DIFF
--- a/client/src/tests/components/Select.test.tsx
+++ b/client/src/tests/components/Select.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Select } from '../../components/ui/Select'
+
+describe('Select Component', () => {
+	it('renders correctly with default props', () => {
+		render(
+			<Select>
+				<option value="1">Option 1</option>
+				<option value="2">Option 2</option>
+			</Select>
+		)
+		const select = screen.getByRole('combobox')
+		expect(select).toBeInTheDocument()
+		expect(select).not.toBeDisabled()
+		expect(select).toHaveClass('text-sm') // Default md size
+	})
+
+	it('renders with label and helper text', () => {
+		render(
+			<Select label="Test Label" helperText="Test Helper">
+				<option value="1">Option 1</option>
+			</Select>
+		)
+		expect(screen.getByText('Test Label')).toBeInTheDocument()
+		expect(screen.getByText('Test Helper')).toBeInTheDocument()
+		expect(screen.getByRole('combobox')).toHaveAccessibleName('Test Label')
+	})
+
+	it('renders error state correctly', () => {
+		render(
+			<Select error errorMessage="Test Error">
+				<option value="1">Option 1</option>
+			</Select>
+		)
+		const select = screen.getByRole('combobox')
+		expect(select).toHaveAttribute('aria-invalid', 'true')
+		expect(screen.getByText('Test Error')).toBeInTheDocument()
+		expect(select).toHaveClass('border-error-300')
+	})
+
+	it('handles disabled state', () => {
+		render(
+			<Select disabled>
+				<option value="1">Option 1</option>
+			</Select>
+		)
+		expect(screen.getByRole('combobox')).toBeDisabled()
+	})
+
+	it('handles size variants', () => {
+		const { rerender } = render(
+			<Select size="sm">
+				<option>Small</option>
+			</Select>
+		)
+		let select = screen.getByRole('combobox')
+		expect(select).toHaveClass('py-1.5')
+
+		rerender(
+			<Select size="lg">
+				<option>Large</option>
+			</Select>
+		)
+		select = screen.getByRole('combobox')
+		expect(select).toHaveClass('py-3')
+	})
+
+	it('handles user interaction', async () => {
+		const handleChange = vi.fn()
+		render(
+			<Select onChange={handleChange}>
+				<option value="1">Option 1</option>
+				<option value="2">Option 2</option>
+			</Select>
+		)
+
+		const select = screen.getByRole('combobox')
+		await userEvent.selectOptions(select, '2')
+
+		expect(handleChange).toHaveBeenCalled()
+		expect(select).toHaveValue('2')
+	})
+
+	it('applies fullWidth class when prop is true', () => {
+		const { container } = render(
+			<Select fullWidth>
+				<option>Full Width</option>
+			</Select>
+		)
+		// Check the container div for w-full
+		expect(container.firstChild).toHaveClass('w-full')
+	})
+
+    it('forwards ref correctly', () => {
+        const ref = React.createRef<HTMLSelectElement>()
+        render(<Select ref={ref}><option>Ref Test</option></Select>)
+        expect(ref.current).toBeInstanceOf(HTMLSelectElement)
+    })
+})

--- a/client/src/tests/components/Select.test.tsx
+++ b/client/src/tests/components/Select.test.tsx
@@ -94,7 +94,7 @@ describe('Select Component', () => {
 	})
 
     it('forwards ref correctly', () => {
-        const ref = React.createRef<HTMLSelectElement>()
+        const ref = { current: null }
         render(<Select ref={ref}><option>Ref Test</option></Select>)
         expect(ref.current).toBeInstanceOf(HTMLSelectElement)
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,6 +1115,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1131,6 +1132,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1147,6 +1149,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1163,6 +1166,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1179,6 +1183,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1195,6 +1200,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1211,6 +1217,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1227,6 +1234,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1243,6 +1251,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1259,6 +1268,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1275,6 +1285,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1291,6 +1302,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1307,6 +1319,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1323,6 +1336,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1339,6 +1353,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1355,6 +1370,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1371,6 +1387,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1387,6 +1404,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1403,6 +1421,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1419,6 +1438,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1435,6 +1455,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1451,6 +1472,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1467,6 +1489,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1483,6 +1506,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1499,6 +1523,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1515,6 +1540,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2680,6 +2706,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2693,6 +2720,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2706,6 +2734,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2719,6 +2748,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2732,6 +2762,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2745,6 +2776,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2758,6 +2790,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2771,6 +2804,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2784,6 +2818,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2797,6 +2832,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2810,6 +2846,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2823,6 +2860,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2836,6 +2874,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2849,6 +2888,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2862,6 +2902,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2875,6 +2916,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2888,6 +2930,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2901,6 +2944,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2914,6 +2958,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2927,6 +2972,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2940,6 +2986,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2953,6 +3000,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3712,7 +3760,7 @@
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
 			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5455,6 +5503,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5486,7 +5535,7 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
 			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -6898,7 +6947,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7368,7 +7417,7 @@
 			"version": "4.21.0",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.27.0",
@@ -7454,7 +7503,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,7 +1115,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1132,7 +1131,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1149,7 +1147,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1166,7 +1163,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1183,7 +1179,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1200,7 +1195,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1217,7 +1211,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1234,7 +1227,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1251,7 +1243,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1268,7 +1259,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1285,7 +1275,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1302,7 +1291,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1319,7 +1307,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1336,7 +1323,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1353,7 +1339,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1370,7 +1355,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1387,7 +1371,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1404,7 +1387,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1421,7 +1403,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1438,7 +1419,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1455,7 +1435,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1472,7 +1451,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1489,7 +1467,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1506,7 +1483,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1523,7 +1499,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1540,7 +1515,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2706,7 +2680,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2720,7 +2693,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2734,7 +2706,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2748,7 +2719,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2762,7 +2732,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2776,7 +2745,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2790,7 +2758,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2804,7 +2771,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2818,7 +2784,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2832,7 +2797,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2846,7 +2810,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2860,7 +2823,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2874,7 +2836,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2888,7 +2849,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2902,7 +2862,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2916,7 +2875,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2930,7 +2888,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2944,7 +2901,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2958,7 +2914,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2972,7 +2927,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2986,7 +2940,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3000,7 +2953,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3760,7 +3712,7 @@
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
 			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5503,7 +5455,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5535,7 +5486,7 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
 			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -6947,7 +6898,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7417,7 +7368,7 @@
 			"version": "4.21.0",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.27.0",
@@ -7503,7 +7454,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -24,6 +24,45 @@ import { prisma } from './lib/prisma.js'
 import { config } from './config.js'
 import { logger } from './lib/logger.js'
 
+/**
+ * Validates the Digest header against the request body
+ * Supports SHA-256 algorithm (case-insensitive)
+ * Handles multiple comma-separated digest values
+ */
+async function validateDigest(bodyText: string, digestHeader: string | undefined): Promise<boolean> {
+	if (!digestHeader) return true
+
+	const digest = await createDigest(bodyText)
+	// createDigest returns "SHA-256=...", so we slice after the first "="
+	const digestValue = digest.slice(digest.indexOf('=') + 1)
+	const digestParts = digestHeader.split(',')
+
+	for (const part of digestParts) {
+		const trimmed = part.trim()
+		const firstEqual = trimmed.indexOf('=')
+		if (firstEqual === -1) continue
+
+		const algo = trimmed.slice(0, firstEqual)
+		const val = trimmed.slice(firstEqual + 1)
+
+		if (algo.toLowerCase() === 'sha-256') {
+			return val === digestValue
+		}
+	}
+
+	// If SHA-256 is present but didn't match, we would have returned false in loop?
+	// No, the loop logic above is: if we find SHA-256, we return comparison result.
+	// Wait, my previous loop logic was:
+	// if found sha-256, store it.
+	// if stored, compare.
+	// Refined logic:
+	// Loop: if algo is sha-256 -> return val === digestValue.
+	// If loop finishes without returning, it means SHA-256 was not found in header.
+	// In that case, we default to valid (true) or invalid?
+	// Current decision: Only enforce if SHA-256 is present.
+	return true
+}
+
 const app = new Hono()
 
 // Maximum request body size for ActivityPub inbox endpoints (1MB)
@@ -574,12 +613,10 @@ app.post(
 
 			// Verify digest if present
 			const digestHeader = c.req.header('digest')
-			if (digestHeader) {
-				const digest = await createDigest(bodyText)
-				if (digest !== digestHeader) {
-					logger.error('[Inbox] Digest mismatch')
-					return c.json({ error: 'Invalid digest' }, 401)
-				}
+			const isDigestValid = await validateDigest(bodyText, digestHeader)
+			if (!isDigestValid) {
+				logger.error('[Inbox] Digest mismatch')
+				return c.json({ error: 'Invalid digest' }, 401)
 			}
 
 			// Parse activity with error handling to prevent DoS from malformed JSON
@@ -686,12 +723,10 @@ app.post(
 
 			// Verify digest if present
 			const digestHeader = c.req.header('digest')
-			if (digestHeader) {
-				const digest = await createDigest(bodyText)
-				if (digest !== digestHeader) {
-					logger.error('[Shared Inbox] Digest mismatch')
-					return c.json({ error: 'Invalid digest' }, 401)
-				}
+			const isDigestValid = await validateDigest(bodyText, digestHeader)
+			if (!isDigestValid) {
+				logger.error('[Shared Inbox] Digest mismatch')
+				return c.json({ error: 'Invalid digest' }, 401)
 			}
 
 			// Parse activity with error handling to prevent DoS from malformed JSON

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -11,7 +11,7 @@ import {
 	createOrderedCollectionPage,
 } from './lib/activitypubHelpers.js'
 import { canViewPrivateProfile } from './lib/privacy.js'
-import { verifySignature } from './lib/httpSignature.js'
+import { verifySignature, createDigest } from './lib/httpSignature.js'
 import { ActivitySchema, PersonSchema, EventSchema } from './lib/activitypubSchemas.js'
 import {
 	ACTIVITYPUB_CONTEXTS,
@@ -563,10 +563,29 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read body text first to verify digest
+			let bodyText: string
+			try {
+				bodyText = await c.req.text()
+			} catch (error) {
+				logger.error('[Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify digest if present
+			const digestHeader = c.req.header('digest')
+			if (digestHeader) {
+				const digest = await createDigest(bodyText)
+				if (digest !== digestHeader) {
+					logger.error('[Inbox] Digest mismatch')
+					return c.json({ error: 'Invalid digest' }, 401)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(bodyText) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {
@@ -656,10 +675,29 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read body text first to verify digest
+			let bodyText: string
+			try {
+				bodyText = await c.req.text()
+			} catch (error) {
+				logger.error('[Shared Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify digest if present
+			const digestHeader = c.req.header('digest')
+			if (digestHeader) {
+				const digest = await createDigest(bodyText)
+				if (digest !== digestHeader) {
+					logger.error('[Shared Inbox] Digest mismatch')
+					return c.json({ error: 'Invalid digest' }, 401)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(bodyText) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {

--- a/src/tests/activitypub.test.ts
+++ b/src/tests/activitypub.test.ts
@@ -550,6 +550,56 @@ describe('ActivityPub API', () => {
 			expect(body.error).toBe('Invalid digest')
 		})
 
+		it('should accept valid activity with valid digest', async () => {
+			vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const bodyStr = JSON.stringify(mockActivity)
+			const crypto = await import('crypto')
+			const hash = crypto.createHash('sha256')
+			hash.update(bodyStr)
+			const digest = `SHA-256=${hash.digest('base64')}`
+
+			const res = await app.request('/users/alice/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature: 'valid_signature',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest,
+				},
+				body: bodyStr,
+			})
+
+			expect(res.status).toBe(202)
+		})
+
+		it('should accept valid activity with case-insensitive digest algorithm', async () => {
+			vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const bodyStr = JSON.stringify(mockActivity)
+			const crypto = await import('crypto')
+			const hash = crypto.createHash('sha256')
+			hash.update(bodyStr)
+			const digest = `sha-256=${hash.digest('base64')}`
+
+			const res = await app.request('/users/alice/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature: 'valid_signature',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest,
+				},
+				body: bodyStr,
+			})
+
+			expect(res.status).toBe(202)
+		})
+
 		it('should return 404 when user not found', async () => {
 			vi.mocked(prisma.user.findUnique).mockResolvedValue(null)
 
@@ -706,6 +756,54 @@ describe('ActivityPub API', () => {
 			expect(res.status).toBe(401)
 			const body = (await res.json()) as { error: string }
 			expect(body.error).toBe('Invalid digest')
+		})
+
+		it('should accept valid activity with valid digest', async () => {
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const bodyStr = JSON.stringify(mockActivity)
+			const crypto = await import('crypto')
+			const hash = crypto.createHash('sha256')
+			hash.update(bodyStr)
+			const digest = `SHA-256=${hash.digest('base64')}`
+
+			const res = await app.request('/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature: 'valid_signature',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest,
+				},
+				body: bodyStr,
+			})
+
+			expect(res.status).toBe(202)
+		})
+
+		it('should accept valid activity with case-insensitive digest algorithm', async () => {
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const bodyStr = JSON.stringify(mockActivity)
+			const crypto = await import('crypto')
+			const hash = crypto.createHash('sha256')
+			hash.update(bodyStr)
+			const digest = `sha-256=${hash.digest('base64')}`
+
+			const res = await app.request('/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature: 'valid_signature',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest,
+				},
+				body: bodyStr,
+			})
+
+			expect(res.status).toBe(202)
 		})
 
 		it('should return 401 when signature is missing', async () => {

--- a/src/tests/activitypub.test.ts
+++ b/src/tests/activitypub.test.ts
@@ -40,9 +40,13 @@ vi.mock('../lib/prisma.js', () => ({
 	},
 }))
 
-vi.mock('../lib/httpSignature.js', () => ({
-	verifySignature: vi.fn(),
-}))
+vi.mock('../lib/httpSignature.js', async () => {
+    const actual = await vi.importActual<typeof import('../lib/httpSignature.js')>('../lib/httpSignature.js')
+    return {
+        ...actual,
+        verifySignature: vi.fn(),
+    }
+})
 
 vi.mock('../federation.js', () => ({
 	handleActivity: vi.fn(),
@@ -523,6 +527,29 @@ describe('ActivityPub API', () => {
 			expect(handleActivity).toHaveBeenCalledWith(mockActivity)
 		})
 
+		it('should return 401 when digest is invalid', async () => {
+			vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const res = await app.request('/users/alice/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature:
+						'keyId="https://remote.com/users/bob#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="mock_signature"',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest: 'SHA-256=invalid_digest',
+				},
+				body: JSON.stringify(mockActivity),
+			})
+
+			// Initially this will fail (it returns 202). We expect it to be 401 after fix.
+			expect(res.status).toBe(401)
+			const body = (await res.json()) as { error: string }
+			expect(body.error).toBe('Invalid digest')
+		})
+
 		it('should return 404 when user not found', async () => {
 			vi.mocked(prisma.user.findUnique).mockResolvedValue(null)
 
@@ -657,6 +684,28 @@ describe('ActivityPub API', () => {
 			const body = (await res.json()) as { status: string }
 			expect(body.status).toBe('accepted')
 			expect(handleActivity).toHaveBeenCalledWith(mockActivity)
+		})
+
+		it('should return 401 when digest is invalid', async () => {
+			vi.mocked(verifySignature).mockResolvedValue(true)
+
+			const res = await app.request('/inbox', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/activity+json',
+					signature:
+						'keyId="https://remote.com/users/bob#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="mock_signature"',
+					host: 'localhost:3000',
+					date: new Date().toISOString(),
+					digest: 'SHA-256=invalid_digest',
+				},
+				body: JSON.stringify(mockActivity),
+			})
+
+			// Initially this will fail (it returns 202). We expect it to be 401 after fix.
+			expect(res.status).toBe(401)
+			const body = (await res.json()) as { error: string }
+			expect(body.error).toBe('Invalid digest')
 		})
 
 		it('should return 401 when signature is missing', async () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: ActivityPub inbox endpoints were verifying HTTP signatures against headers but not verifying that the `Digest` header matched the request body. This allowed an attacker to replay a valid signature with a modified body.
🎯 Impact: An attacker could forge activities (e.g., Delete, Follow) appearing to come from a legitimate actor by reusing a valid signature.
🔧 Fix: Implemented SHA-256 digest verification of the raw request body against the `Digest` header before processing the activity.
✅ Verification: Added new test cases in `src/tests/activitypub.test.ts` that send requests with valid signatures but mismatched digests, asserting that they are rejected with 401 Unauthorized.

---
*PR created automatically by Jules for task [1098475610460683544](https://jules.google.com/task/1098475610460683544) started by @burnoutberni*