### PR TITLE
🎨 Palette: Add Clear Button to Search Bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Interactive Input Icons
+**Learning:** The `Input` component's right icon container has `pointer-events-none` by default, blocking interactions.
+**Action:** When adding interactive elements (like clear buttons) to `Input` right icon slot, use the `rightIconInteractive` prop (added in this PR) to enable pointer events.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,26 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
+	let rightIcon
+	if (isLoading) {
+		rightIcon = <Spinner size="sm" variant="secondary" />
+	} else if (query) {
+		rightIcon = (
+			<button
+				type="button"
+				onClick={handleClear}
+				className="p-1 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 text-text-tertiary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
+				aria-label="Clear search">
+				<CloseIcon className="w-4 h-4" />
+			</button>
+		)
+	}
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +208,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={!!query && !isLoading}
 				className="w-full"
 			/>
 

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -209,7 +209,7 @@ export function SearchBar() {
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
 				rightIcon={rightIcon}
-				rightIconInteractive={!!query && !isLoading}
+				rightIconInteractive={Boolean(query) && !isLoading}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Mock } from 'vitest'
 import { SearchBar } from '../../components/SearchBar'
 import { createTestWrapper, clearQueryClient } from '../testUtils'
 import { api } from '../../lib/api-client'
@@ -29,12 +30,12 @@ describe('SearchBar Component', () => {
 	beforeEach(() => {
 		clearQueryClient(queryClient)
 		vi.clearAllMocks()
-        // Mock api.get to return empty results
-        ;(api.get as any).mockResolvedValue({
-            users: [],
-            events: [],
-            remoteAccountSuggestion: null
-        })
+		// Mock api.get to return empty results
+		;(api.get as Mock).mockResolvedValue({
+			users: [],
+			events: [],
+			remoteAccountSuggestion: null,
+		})
 	})
 
 	it('should render search input', () => {

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper, clearQueryClient } from '../testUtils'
+import { api } from '../../lib/api-client'
+
+// Mock dependencies
+const mockUseQuery = vi.fn()
+
+vi.mock('@tanstack/react-query', async () => {
+	const actual = await vi.importActual('@tanstack/react-query')
+	return {
+		...actual,
+		useQuery: () => mockUseQuery(),
+	}
+})
+
+vi.mock('../../lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+const { wrapper, queryClient } = createTestWrapper()
+
+describe('SearchBar Component', () => {
+	beforeEach(() => {
+		clearQueryClient(queryClient)
+		vi.clearAllMocks()
+        // Mock api.get to return empty results
+        ;(api.get as any).mockResolvedValue({
+            users: [],
+            events: [],
+            remoteAccountSuggestion: null
+        })
+	})
+
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper })
+		expect(screen.getByPlaceholderText(/search events, users/i)).toBeInTheDocument()
+	})
+
+	it('should show clear button when typing', async () => {
+		const user = userEvent.setup()
+		render(<SearchBar />, { wrapper })
+
+		const input = screen.getByPlaceholderText(/search events, users/i)
+		await user.type(input, 'test')
+
+        // Wait for loading to finish (debounce + async call)
+        await waitFor(() => {
+            expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+        })
+	})
+
+	it('should not show clear button when empty', () => {
+		render(<SearchBar />, { wrapper })
+		const clearButton = screen.queryByLabelText('Clear search')
+		expect(clearButton).not.toBeInTheDocument()
+	})
+
+	it('should clear input and focus when clear button is clicked', async () => {
+		const user = userEvent.setup()
+		render(<SearchBar />, { wrapper })
+
+		const input = screen.getByPlaceholderText(/search events, users/i)
+		await user.type(input, 'test')
+
+        // Wait for clear button to appear
+        await waitFor(() => {
+            expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+        })
+
+		const clearButton = screen.getByLabelText('Clear search')
+		await user.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+	})
+})


### PR DESCRIPTION
*   💡 **What**: Added a clear button (X icon) to the search bar that appears when there is text input.
*   🎯 **Why**: Users had to manually delete text to clear the search, which is cumbersome. This improves search usability.
*   📸 **Before/After**: Added a clickable X icon on the right side of the input.
*   ♿ **Accessibility**: The clear button is keyboard accessible (tabbable) and has an `aria-label="Clear search"`. Focus is restored to the input after clearing.

---
*PR created automatically by Jules for task [2308641845145001176](https://jules.google.com/task/2308641845145001176) started by @burnoutberni*