### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limiting bypass via IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Secure IP Extraction from X-Forwarded-For
+**Vulnerability:** Rate limiting bypass was possible because the application extracted the *first* IP from the `X-Forwarded-For` header. Attackers could spoof this by sending a header like `X-Forwarded-For: spoofed-ip`.
+**Learning:** In standard reverse proxy configurations (like Caddy default), the proxy *appends* the connecting client's IP to the list. Thus, `X-Forwarded-For` becomes `spoofed-ip, real-ip`. The application must trust the *last* IP in the list (the one added by the trusted proxy).
+**Prevention:** Always extract the **last** IP from `X-Forwarded-For` when behind a trusted proxy that appends IPs. This works securely even if the proxy is configured to replace the header (list length 1).

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -85,8 +85,13 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 	return async (c: Context, next: Next) => {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
-		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+		// In a trusted proxy setup (like Caddy), the proxy appends the client IP to the X-Forwarded-For list.
+		// To prevent spoofing (where a client sends a fake X-Forwarded-For header), we must use the LAST IP in the list,
+		// which is the one added by our trusted proxy.
+		const forwardedFor = c.req.header('x-forwarded-for')
+		const ip = forwardedFor
+			? forwardedFor.split(',').pop()?.trim() || 'unknown'
+			: c.req.header('x-real-ip') || 'unknown'
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.security.test.ts
+++ b/src/tests/middleware/rateLimit.security.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import { rateLimit } from '../../middleware/rateLimit.js'
+import { handleError } from '../../lib/errors.js'
+
+describe('Rate Limit Security', () => {
+	it('should prevent rate limit bypass via X-Forwarded-For spoofing', async () => {
+		const app = new Hono()
+		app.onError(handleError)
+
+		// Configure strict rate limit: 2 requests per window
+		app.use(
+			'*',
+			rateLimit({
+				windowMs: 15 * 60 * 1000,
+				maxRequests: 2,
+				keyGenerator: undefined, // Use default IP-based key
+			})
+		)
+
+		app.get('/', (c) => c.text('ok'))
+
+		const realIp = '203.0.113.5'
+		const spoofedIp1 = '198.51.100.1'
+		const spoofedIp2 = '198.51.100.2'
+		const spoofedIp3 = '198.51.100.3'
+
+		// Request 1: Allow
+		const res1 = await app.request('/', {
+			headers: {
+				'X-Forwarded-For': `${spoofedIp1}, ${realIp}`,
+			},
+		})
+		expect(res1.status).toBe(200)
+
+		// Request 2: Allow
+		const res2 = await app.request('/', {
+			headers: {
+				'X-Forwarded-For': `${spoofedIp2}, ${realIp}`,
+			},
+		})
+		expect(res2.status).toBe(200)
+
+		// Request 3: Should trigger rate limit because real IP is the same
+		// BUT currently it fails (vulnerability exists) because it uses the first IP (spoofed)
+		const res3 = await app.request('/', {
+			headers: {
+				'X-Forwarded-For': `${spoofedIp3}, ${realIp}`,
+			},
+		})
+
+		// ----------------------------------------------------------------
+		// SECURITY FIX VERIFICATION
+		// With the fix, the rate limiter should see the REAL IP (which is constant)
+		// and ignore the spoofed IP.
+		// Since we've made 2 requests from this real IP already, the 3rd request
+		// should be blocked (429 Too Many Requests).
+		// ----------------------------------------------------------------
+		expect(res3.status).toBe(429)
+	})
+})


### PR DESCRIPTION
This PR addresses a security vulnerability in the rate limiting middleware where the IP address was extracted from the *first* entry of the `X-Forwarded-For` header. This allowed attackers to bypass rate limits by sending a spoofed `X-Forwarded-For` header (e.g., `X-Forwarded-For: spoofed-ip`).

The fix updates the logic to use the **last** IP in the `X-Forwarded-For` list, which corresponds to the client IP added by the trusted proxy (Caddy) in standard configurations. This ensures that the rate limiter uses the IP address verified by the proxy infrastructure.

**Changes:**
- `src/middleware/rateLimit.ts`: Changed IP extraction to `c.req.header('x-forwarded-for')?.split(',').pop()?.trim()`.
- `src/tests/middleware/rateLimit.security.test.ts`: Added a new test file that reproduces the vulnerability and verifies the fix.
- `.jules/sentinel.md`: Added a security journal entry documenting the vulnerability and the fix pattern.

**Verification:**
- A new test case `src/tests/middleware/rateLimit.security.test.ts` was added.
- The test simulates a request with `X-Forwarded-For: spoofed, real`.
- Before the fix, the rate limiter would count against `spoofed`.
- After the fix, the rate limiter counts against `real`, and blocks requests when the limit is exceeded for `real` IP, regardless of the `spoofed` IP.
- Ran `npm test src/tests/middleware/rateLimit.security.test.ts` to confirm it passes.
- Ran `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [16854559962069548937](https://jules.google.com/task/16854559962069548937) started by @burnoutberni*