### PR TITLE
🎨 Palette: Add Clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -138,6 +138,14 @@ export function SearchBar() {
 		setIsOpen(false)
 	}
 
+	// Clear search
+	const handleClear = () => {
+		setQuery('')
+		setResults(null)
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	// Keyboard navigation
 	const handleKeyDown = (e: KeyboardEvent) => {
 		if (!isOpen) {
@@ -176,7 +184,21 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const clearIcon = (
+		<button
+			type="button"
+			onClick={handleClear}
+			className="p-1 hover:text-text-primary rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	)
+
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		clearIcon
+	) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +211,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={Boolean(query) && !isLoading}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,11 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 * @default false
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +60,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +163,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,16 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should apply pointer-events-none to right icon container by default', () => {
+		render(<Input type="text" rightIcon={<span>Icon</span>} />)
+		const iconContainer = screen.getByText('Icon').parentElement
+		expect(iconContainer).toHaveClass('pointer-events-none')
+	})
+
+	it('should remove pointer-events-none from right icon container when rightIconInteractive is true', () => {
+		render(<Input type="text" rightIcon={<span>Icon</span>} rightIconInteractive />)
+		const iconContainer = screen.getByText('Icon').parentElement
+		expect(iconContainer).not.toHaveClass('pointer-events-none')
+	})
 })


### PR DESCRIPTION
💡 What: Added a "Clear" (X) button to the SearchBar that appears when there is text.
🎯 Why: To allow users to quickly clear their search query without manually deleting text.
📸 Verification: Verified with Playwright screenshots.
♿ Accessibility: The button is keyboard accessible (focusable) and has an aria-label "Clear search". Focus is returned to the input after clearing.

---
*PR created automatically by Jules for task [16864678616922399794](https://jules.google.com/task/16864678616922399794) started by @burnoutberni*