### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -206,7 +206,7 @@ export function SearchBar() {
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
 				rightIcon={isLoading ? loadingSpinner : clearButton}
-				rightIconInteractive={!!clearButton}
+				rightIconInteractive={Boolean(clearButton)}
 				className="w-full"
 			/>
 

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -139,6 +139,12 @@ export function SearchBar() {
 	}
 
 	// Keyboard navigation
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
 	const handleKeyDown = (e: KeyboardEvent) => {
 		if (!isOpen) {
 			return
@@ -177,6 +183,16 @@ export function SearchBar() {
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
 	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const clearButton =
+		query && !isLoading ? (
+			<button
+				type="button"
+				onClick={handleClear}
+				className="p-1 hover:text-text-primary hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+				aria-label="Clear search">
+				<CloseIcon className="w-4 h-4" />
+			</button>
+		) : undefined
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +205,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={isLoading ? loadingSpinner : clearButton}
+				rightIconInteractive={!!clearButton}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,11 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 * If true, pointer-events will not be disabled on the icon container
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +60,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +163,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,24 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should disable pointer events on right icon container by default', () => {
+		render(<Input type="text" rightIcon={<span data-testid="right-icon">✓</span>} />)
+		const icon = screen.getByTestId('right-icon')
+		// The parent div should have pointer-events-none
+		expect(icon.parentElement).toHaveClass('pointer-events-none')
+	})
+
+	it('should enable pointer events on right icon container when rightIconInteractive is true', () => {
+		render(
+			<Input
+				type="text"
+				rightIcon={<span data-testid="right-icon">✓</span>}
+				rightIconInteractive
+			/>
+		)
+		const icon = screen.getByTestId('right-icon')
+		// The parent div should NOT have pointer-events-none
+		expect(icon.parentElement).not.toHaveClass('pointer-events-none')
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+import { api } from '@/lib/api-client'
+
+// Mock API
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar Component', () => {
+	const { wrapper } = createTestWrapper()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper })
+		expect(screen.getByPlaceholderText(/Search events, users/i)).toBeInTheDocument()
+	})
+
+	it('should show clear button after search finishes', async () => {
+		// Mock API response
+		(api.get as any).mockResolvedValue({
+			users: [],
+			events: [],
+			remoteAccountSuggestion: null,
+		})
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		// Type something
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Wait for clear button to appear (after debounce and API call)
+		await waitFor(
+			() => {
+				expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+			},
+			{ timeout: 2000 }
+		)
+	})
+
+	it('should clear input and focus when clear button is clicked', async () => {
+		(api.get as any).mockResolvedValue({
+			users: [],
+			events: [],
+			remoteAccountSuggestion: null,
+		})
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i) as HTMLInputElement
+
+		// Type something
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Wait for clear button
+		await waitFor(
+			() => {
+				expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+			},
+			{ timeout: 2000 }
+		)
+
+		const clearButton = screen.getByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		// Verify input is cleared and focused
+		expect(input.value).toBe('')
+		expect(input).toHaveFocus()
+	})
+})

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -26,7 +26,7 @@ describe('SearchBar Component', () => {
 
 	it('should show clear button after search finishes', async () => {
 		// Mock API response
-		(api.get as any).mockResolvedValue({
+		vi.mocked(api.get).mockResolvedValue({
 			users: [],
 			events: [],
 			remoteAccountSuggestion: null,
@@ -48,7 +48,7 @@ describe('SearchBar Component', () => {
 	})
 
 	it('should clear input and focus when clear button is clicked', async () => {
-		(api.get as any).mockResolvedValue({
+		vi.mocked(api.get).mockResolvedValue({
 			users: [],
 			events: [],
 			remoteAccountSuggestion: null,


### PR DESCRIPTION
💡 **What**: Added a "Clear" (X) button to the global SearchBar that appears when there is text in the input.
🎯 **Why**: To improve user experience by allowing users to quickly clear their search query without manually deleting text.
📸 **Before/After**: Before: No clear button. After: An 'X' button appears on the right side of the input when typing.
♿ **Accessibility**: The button is keyboard accessible (tabbable), has an `aria-label="Clear search"`, and explicitly returns focus to the input field after clicking.


---
*PR created automatically by Jules for task [2745725935604590746](https://jules.google.com/task/2745725935604590746) started by @burnoutberni*