### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in ActivityPub Federation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Stored XSS in ActivityPub Federation
+**Vulnerability:** Incoming ActivityPub objects (Events, Notes, Profiles) were stored directly in the database without sanitization, allowing remote instances to inject XSS payloads via `summary`, `content`, and `bio` fields.
+**Learning:** Federated applications must treat remote data as untrusted user input, even if it comes from "server-to-server" communication. Local input validation (Zod) is insufficient if the ingress path for federation bypasses it.
+**Prevention:** Apply strict HTML sanitization (e.g., `isomorphic-dompurify`) on all text/HTML fields at the ingress point (`src/federation.ts`) before database storage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,7 +1115,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1132,7 +1131,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1149,7 +1147,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1166,7 +1163,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1183,7 +1179,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1200,7 +1195,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1217,7 +1211,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1234,7 +1227,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1251,7 +1243,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1268,7 +1259,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1285,7 +1275,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1302,7 +1291,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1319,7 +1307,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1336,7 +1323,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1353,7 +1339,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1370,7 +1355,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1387,7 +1371,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1404,7 +1387,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1421,7 +1403,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1438,7 +1419,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1455,7 +1435,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1472,7 +1451,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1489,7 +1467,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1506,7 +1483,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1523,7 +1499,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1540,7 +1515,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2706,7 +2680,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2720,7 +2693,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2734,7 +2706,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2748,7 +2719,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2762,7 +2732,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2776,7 +2745,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2790,7 +2758,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2804,7 +2771,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2818,7 +2784,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2832,7 +2797,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2846,7 +2810,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2860,7 +2823,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2874,7 +2836,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2888,7 +2849,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2902,7 +2862,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2916,7 +2875,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2930,7 +2888,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2944,7 +2901,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2958,7 +2914,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2972,7 +2927,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2986,7 +2940,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3000,7 +2953,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3760,7 +3712,7 @@
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
 			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5503,7 +5455,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5535,7 +5486,7 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
 			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -6947,7 +6898,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7417,7 +7368,7 @@
 			"version": "4.21.0",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.27.0",
@@ -7503,7 +7454,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -11,6 +11,7 @@ import {
 	fetchRemoteCollectionCount,
 } from './lib/activitypubHelpers.js'
 import { safeFetch } from './lib/ssrfProtection.js'
+import { sanitizeText, sanitizeHtml } from './lib/sanitization.js'
 import { buildAcceptActivity } from './services/ActivityBuilder.js'
 import { deliverToInbox } from './services/ActivityDelivery.js'
 import { broadcast, broadcastToUser, BroadcastEvents } from './realtime.js'
@@ -562,15 +563,15 @@ async function upsertRemoteEventFromObject(event: ActivityPubEvent | Record<stri
 	}
 
 	const eventData = {
-		title: eventName,
-		summary: eventSummary || eventContent || null,
-		location: locationValue,
+		title: sanitizeText(eventName),
+		summary: (eventSummary || eventContent) ? sanitizeHtml(eventSummary || eventContent || '') : null,
+		location: locationValue ? sanitizeText(locationValue) : null,
 		startTime: new Date(eventStartTime),
 		endTime: eventEndTime ? new Date(eventEndTime) : null,
 		duration: eventDuration || null,
 		url: eventUrl || null,
-		eventStatus: eventStatus as string | null,
-		eventAttendanceMode: eventAttendanceMode as string | null,
+		eventStatus: eventStatus ? sanitizeText(eventStatus as string) : null,
+		eventAttendanceMode: eventAttendanceMode ? sanitizeText(eventAttendanceMode as string) : null,
 		maximumAttendeeCapacity: eventMaxCapacity,
 		headerImage: attachmentUrl,
 		attributedTo: attributedTo,
@@ -734,15 +735,15 @@ async function handleCreateEvent(
 
 	// Create event in database
 	const eventData = {
-		title: eventName,
-		summary: eventSummary || eventContent || null,
-		location: locationValue,
+		title: sanitizeText(eventName),
+		summary: (eventSummary || eventContent) ? sanitizeHtml(eventSummary || eventContent || '') : null,
+		location: locationValue ? sanitizeText(locationValue) : null,
 		startTime: new Date(eventStartTime),
 		endTime: eventEndTime ? new Date(eventEndTime) : null,
 		duration: eventDuration || null,
 		url: eventUrl || null,
-		eventStatus: eventStatus as string | null,
-		eventAttendanceMode: eventAttendanceMode as string | null,
+		eventStatus: eventStatus ? sanitizeText(eventStatus as string) : null,
+		eventAttendanceMode: eventAttendanceMode ? sanitizeText(eventAttendanceMode as string) : null,
 		maximumAttendeeCapacity: eventMaxCapacity,
 		headerImage: attachmentUrl,
 		attributedTo: attributedTo || activity.actor,
@@ -804,7 +805,7 @@ async function handleCreateNote(
 	const comment = await prisma.comment.create({
 		data: {
 			externalId: noteId,
-			content: noteContent,
+			content: sanitizeHtml(noteContent),
 			eventId: event.id,
 			authorId: remoteUser.id,
 		},
@@ -916,12 +917,12 @@ async function handleUpdateEvent(event: ActivityPubEvent | Record<string, unknow
 	await prisma.event.updateMany({
 		where: { externalId: eventId },
 		data: {
-			title: eventName,
-			summary: eventSummary || null,
-			location: locationValue,
+			title: sanitizeText(eventName),
+			summary: eventSummary ? sanitizeHtml(eventSummary) : null,
+			location: locationValue ? sanitizeText(locationValue) : null,
 			startTime: new Date(eventStartTime),
 			endTime: eventEndTime ? new Date(eventEndTime) : null,
-			eventStatus: eventStatus as string | null,
+			eventStatus: eventStatus ? sanitizeText(eventStatus as string) : null,
 		},
 	})
 
@@ -955,8 +956,8 @@ async function handleUpdatePerson(person: Person | Record<string, unknown>): Pro
 	await prisma.user.updateMany({
 		where: { externalActorUrl: personId },
 		data: {
-			name: personName,
-			bio: personSummary,
+			name: personName ? sanitizeText(personName) : undefined,
+			bio: personSummary ? sanitizeHtml(personSummary) : undefined,
 			displayColor: personDisplayColor,
 			profileImage: personIconUrl,
 			headerImage: personImageUrl,

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -16,3 +16,41 @@ export function sanitizeText(input: string): string {
 		ALLOWED_ATTR: [],
 	})
 }
+
+/**
+ * Sanitizes HTML content, allowing a safe subset of tags and attributes
+ * @param input - Raw HTML content
+ * @returns Sanitized HTML safe for storage/display
+ */
+export function sanitizeHtml(input: string): string {
+	return DOMPurify.sanitize(input, {
+		ALLOWED_TAGS: [
+			'p',
+			'br',
+			'strong',
+			'b',
+			'em',
+			'i',
+			'u',
+			's',
+			'strike',
+			'del',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'ul',
+			'ol',
+			'li',
+			'a',
+			'blockquote',
+			'pre',
+			'code',
+			'span',
+			'div',
+		],
+		ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+	})
+}

--- a/src/tests/federation.coverage.test.ts
+++ b/src/tests/federation.coverage.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { config } from 'dotenv'
+config()
+import { handleActivity } from '../federation.js'
+import { ActivityType, ObjectType } from '../constants/activitypub.js'
+import { prisma } from '../lib/prisma.js'
+import * as activitypubHelpers from '../lib/activitypubHelpers.js'
+import * as realtime from '../realtime.js'
+import * as instanceHelpers from '../lib/instanceHelpers.js'
+
+// Mock dependencies
+vi.mock('../lib/activitypubHelpers.js')
+vi.mock('../services/ActivityBuilder.js')
+vi.mock('../services/ActivityDelivery.js')
+vi.mock('../realtime.js')
+vi.mock('../lib/instanceHelpers.js')
+
+describe('Federation Coverage Tests', () => {
+	const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+
+	beforeEach(async () => {
+		// Clean up
+		await prisma.processedActivity.deleteMany({})
+		await prisma.event.deleteMany({})
+		await prisma.user.deleteMany({})
+		vi.clearAllMocks()
+	})
+
+	it('should handle Create activity with empty optional fields (coverage)', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/coverage',
+			type: 'Person',
+			preferredUsername: 'coverage',
+			inbox: 'https://example.com/users/coverage/inbox',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'coverage@example.com',
+				email: 'coverage@example.com',
+				name: 'Coverage',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+				inboxUrl: remoteActor.inbox,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+		vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+		const activity = {
+			id: 'https://example.com/activities/create-minimal',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/minimal',
+				name: 'Minimal Event',
+				startTime: new Date().toISOString(),
+				// Missing summary, location, eventStatus, eventAttendanceMode
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const event = await prisma.event.findFirst({
+			where: { externalId: activity.object.id },
+		})
+
+		expect(event).toBeTruthy()
+		expect(event?.title).toBe('Minimal Event')
+		expect(event?.summary).toBeNull()
+		expect(event?.location).toBeNull()
+		expect(event?.eventStatus).toBeNull()
+		expect(event?.eventAttendanceMode).toBeNull()
+	})
+
+	it('should handle Create activity with all fields (coverage)', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/coverage',
+			type: 'Person',
+			preferredUsername: 'coverage',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'coverage@example.com',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+		const activity = {
+			id: 'https://example.com/activities/create-full',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/full',
+				name: 'Full Event',
+				summary: 'Summary with <b>HTML</b>',
+				location: { name: 'Location Name' },
+				eventStatus: 'EventScheduled',
+				eventAttendanceMode: 'OfflineEventAttendanceMode',
+				startTime: new Date().toISOString(),
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const event = await prisma.event.findFirst({
+			where: { externalId: activity.object.id },
+		})
+
+		expect(event).toBeTruthy()
+		expect(event?.title).toBe('Full Event')
+		expect(event?.summary).toBe('Summary with <b>HTML</b>')
+		expect(event?.location).toBe('Location Name')
+		expect(event?.eventStatus).toBe('EventScheduled')
+		expect(event?.eventAttendanceMode).toBe('OfflineEventAttendanceMode')
+	})
+
+	it('should handle Update activity with empty optional fields (coverage)', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/coverage',
+			type: 'Person',
+			preferredUsername: 'coverage',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'coverage@example.com',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+			},
+		})
+
+		// Create existing event with values
+		await prisma.event.create({
+			data: {
+				title: 'Original Title',
+				summary: 'Original Summary',
+				location: 'Original Location',
+				eventStatus: 'EventScheduled',
+				startTime: new Date(),
+				externalId: 'https://example.com/events/update-coverage',
+				attributedTo: remoteActor.id,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+
+		// Update to clear fields
+		const activity = {
+			id: 'https://example.com/activities/update-clear',
+			type: ActivityType.UPDATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/update-coverage',
+				name: 'Updated Title',
+				startTime: new Date().toISOString(),
+				// Missing summary, location, status implies clearing them in handleUpdateEvent logic
+				// Note: extractEventProperties returns null for missing fields
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const event = await prisma.event.findFirst({
+			where: { externalId: activity.object.id },
+		})
+
+		expect(event?.title).toBe('Updated Title')
+		expect(event?.summary).toBeNull() // Cleared
+		expect(event?.location).toBeNull() // Cleared
+		expect(event?.eventStatus).toBeNull() // Cleared
+	})
+
+	it('should handle Update Person with empty optional fields (coverage)', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/coverage-person',
+			type: 'Person',
+			preferredUsername: 'coverage-person',
+		}
+
+		await prisma.user.create({
+			data: {
+				username: 'coverage-person@example.com',
+				name: 'Original Name',
+				bio: 'Original Bio',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor as any)
+
+		// Update with minimal fields (no name/bio)
+		const activity = {
+			id: 'https://example.com/activities/update-person-minimal',
+			type: ActivityType.UPDATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.PERSON,
+				id: remoteActor.id,
+				preferredUsername: 'coverage-person',
+				// Missing name and summary (bio)
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const user = await prisma.user.findFirst({
+			where: { externalActorUrl: remoteActor.id },
+		})
+
+		// Should NOT clear existing values if they are undefined in the update
+		// handleUpdatePerson uses: name: personName ? ... : undefined
+		// undefined means "do not update" in Prisma
+		expect(user?.name).toBe('Original Name')
+		expect(user?.bio).toBe('Original Bio')
+	})
+
+	it('should handle Update Person with cleared fields (explicit null/empty) (coverage)', async () => {
+		// ActivityPub doesn't strictly define "clearing" via null in JSON-LD always,
+		// but our implementation checks for truthiness.
+		// If we want to clear, we might need to change implementation or just test the truthy path.
+		// Wait, `handleUpdatePerson`:
+		// const personName = personObj.name || undefined
+		// If personObj.name is "", personName becomes undefined.
+		// So we can't clear name with "".
+		// This test just confirms the branch coverage for the "truthy" path.
+
+		const remoteActor = {
+			id: 'https://example.com/users/coverage-person-full',
+			type: 'Person',
+			preferredUsername: 'coverage-person-full',
+		}
+
+		await prisma.user.create({
+			data: {
+				username: 'coverage-person-full@example.com',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+			},
+		})
+
+		const activity = {
+			id: 'https://example.com/activities/update-person-full',
+			type: ActivityType.UPDATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.PERSON,
+				id: remoteActor.id,
+				preferredUsername: 'coverage-person-full',
+				name: 'New Name',
+				summary: 'New Bio',
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const user = await prisma.user.findFirst({
+			where: { externalActorUrl: remoteActor.id },
+		})
+
+		expect(user?.name).toBe('New Name')
+		expect(user?.bio).toBe('New Bio')
+	})
+})

--- a/src/tests/federation.security.test.ts
+++ b/src/tests/federation.security.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { config } from 'dotenv'
+config()
+import { handleActivity } from '../federation.js'
+import { ActivityType, ObjectType } from '../constants/activitypub.js'
+import { prisma } from '../lib/prisma.js'
+import * as activitypubHelpers from '../lib/activitypubHelpers.js'
+import * as realtime from '../realtime.js'
+import * as instanceHelpers from '../lib/instanceHelpers.js'
+
+// Mock dependencies
+vi.mock('../lib/activitypubHelpers.js')
+vi.mock('../services/ActivityBuilder.js')
+vi.mock('../services/ActivityDelivery.js')
+vi.mock('../realtime.js')
+vi.mock('../lib/instanceHelpers.js')
+
+describe('Federation Security (XSS Prevention)', () => {
+	const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+
+	beforeEach(async () => {
+		// Clean up processed activities
+		await prisma.processedActivity.deleteMany({})
+		await prisma.eventAttendance.deleteMany({})
+		await prisma.eventLike.deleteMany({})
+		await prisma.comment.deleteMany({})
+		await prisma.follower.deleteMany({})
+		await prisma.following.deleteMany({})
+		await prisma.event.deleteMany({})
+		await prisma.user.deleteMany({})
+
+		// Reset mocks
+		vi.clearAllMocks()
+	})
+
+	it('should sanitize HTML in Event summary', async () => {
+		const remoteActor = {
+			id: 'https://example.com/users/attacker',
+			type: 'Person',
+			preferredUsername: 'attacker',
+			inbox: 'https://example.com/users/attacker/inbox',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'attacker@example.com',
+				email: 'attacker@example.com',
+				name: 'Attacker',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+				inboxUrl: remoteActor.inbox,
+			},
+		})
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+		vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+		const xssPayload = '<script>alert("XSS")</script>'
+		const safeContent = 'This is safe content'
+
+		const activity = {
+			id: 'https://example.com/activities/create-xss-event',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.EVENT,
+				id: 'https://example.com/events/xss-event',
+				name: 'XSS Event',
+				summary: `${safeContent}${xssPayload}`,
+				startTime: new Date().toISOString(),
+				endTime: new Date(Date.now() + 3600000).toISOString(),
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		// Verify event was created
+		const event = await prisma.event.findFirst({
+			where: {
+				externalId: activity.object.id,
+			},
+		})
+
+		expect(event).toBeTruthy()
+		// Without sanitization, this will contain the script tag
+		// We expect this to fail initially if sanitization is missing
+        // Or if it passes, it means we have a vulnerability to fix.
+        // I'll assert that it SHOULD NOT contain script tags.
+		expect(event?.summary).not.toContain('<script>')
+		expect(event?.summary).toContain(safeContent)
+	})
+
+    it('should sanitize HTML in Comment content', async () => {
+        const remoteActor = {
+			id: 'https://example.com/users/attacker',
+			type: 'Person',
+			preferredUsername: 'attacker',
+			inbox: 'https://example.com/users/attacker/inbox',
+		}
+
+		const remoteUser = await prisma.user.create({
+			data: {
+				username: 'attacker@example.com',
+				email: 'attacker@example.com',
+				name: 'Attacker',
+				isRemote: true,
+				externalActorUrl: remoteActor.id,
+				inboxUrl: remoteActor.inbox,
+			},
+		})
+
+        // Create an event to comment on
+        const testEvent = await prisma.event.create({
+            data: {
+                title: 'Test Event',
+                startTime: new Date(),
+                userId: remoteUser.id,
+            }
+        })
+
+		vi.mocked(activitypubHelpers.fetchActor).mockResolvedValue(remoteActor)
+		vi.mocked(activitypubHelpers.cacheRemoteUser).mockResolvedValue(remoteUser as any)
+		vi.mocked(realtime.broadcast).mockResolvedValue(undefined)
+
+        const xssPayload = '<img src=x onerror=alert(1)>'
+        const safeContent = 'Comment content'
+
+		const activity = {
+			id: 'https://example.com/activities/create-xss-comment',
+			type: ActivityType.CREATE,
+			actor: remoteActor.id,
+			object: {
+				type: ObjectType.NOTE,
+				id: 'https://example.com/comments/xss-comment',
+				content: `${safeContent}${xssPayload}`,
+                inReplyTo: testEvent.id // Local ID or external ID works due to logic
+			},
+		}
+
+		await handleActivity(activity as any)
+
+		const comment = await prisma.comment.findFirst({
+			where: {
+				externalId: activity.object.id,
+			},
+		})
+
+		expect(comment).toBeTruthy()
+        // Expect sanitization to remove onerror or img entirely if img not allowed
+		expect(comment?.content).not.toContain('onerror')
+        expect(comment?.content).toContain(safeContent)
+    })
+})


### PR DESCRIPTION
**Vulnerability:**
Incoming ActivityPub objects (Events, Notes, Profiles) were being stored in the database without sanitization. This allowed remote instances to inject XSS payloads via `summary`, `content`, `bio`, and other text fields. While the frontend uses `SafeHTML` to render some of these fields, storing malicious payloads is a security risk (defense in depth, other clients).

**Fix:**
- Updated `src/lib/sanitization.ts` to include a `sanitizeHtml` function that uses `isomorphic-dompurify` with a safe whitelist of tags and attributes (matching the frontend's `SafeHTML` configuration).
- Updated `src/federation.ts` to sanitize all incoming user-generated content before storage:
    - `sanitizeText` for `title`, `name`, `location`.
    - `sanitizeHtml` for `summary`, `content` (comments), `bio`.

**Verification:**
- Added a new regression test `src/tests/federation.security.test.ts` which confirms that XSS payloads are neutralized.
- Ran existing `src/tests/federation.test.ts` to ensure no regressions in federation logic.

---
*PR created automatically by Jules for task [2463021169846243581](https://jules.google.com/task/2463021169846243581) started by @burnoutberni*