### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing ActivityPub Digest verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-14 - Missing Digest Verification in ActivityPub
+
+**Vulnerability:** ActivityPub inbox handlers validated HTTP Signatures but did not verify the `Digest` header against the request body.
+**Learning:** Signature verification only proves the sender signed the _headers_. If the `Digest` header (which hashes the body) is not checked against the actual body content, an attacker can substitute the body while keeping the valid signature headers, bypassing integrity checks.
+**Prevention:** Always calculate the hash of the request body and compare it to the `Digest` header before processing signed requests.

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -11,7 +11,7 @@ import {
 	createOrderedCollectionPage,
 } from './lib/activitypubHelpers.js'
 import { canViewPrivateProfile } from './lib/privacy.js'
-import { verifySignature } from './lib/httpSignature.js'
+import { verifySignature, createDigest } from './lib/httpSignature.js'
 import { ActivitySchema, PersonSchema, EventSchema } from './lib/activitypubSchemas.js'
 import {
 	ACTIVITYPUB_CONTEXTS,
@@ -563,10 +563,31 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read body text first
+			let bodyText
+			try {
+				bodyText = await c.req.text()
+			} catch (error) {
+				logger.error('[Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify Digest if present (critical for integrity)
+			const digestHeader = c.req.header('digest')
+			if (digestHeader && digestHeader.includes('SHA-256=')) {
+				const calculatedDigest = await createDigest(bodyText)
+				if (!digestHeader.includes(calculatedDigest)) {
+					logger.error(
+						`[Inbox] Digest mismatch. Header: ${digestHeader}, Calculated: ${calculatedDigest}`
+					)
+					return c.json({ error: 'Invalid Digest' }, 400)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(bodyText) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {
@@ -656,10 +677,31 @@ app.post(
 				return c.json({ error: 'Invalid signature' }, 401)
 			}
 
+			// Read body text first
+			let bodyText
+			try {
+				bodyText = await c.req.text()
+			} catch (error) {
+				logger.error('[Shared Inbox] Failed to read request body:', error)
+				return c.json({ error: 'Invalid request body' }, 400)
+			}
+
+			// Verify Digest if present (critical for integrity)
+			const digestHeader = c.req.header('digest')
+			if (digestHeader && digestHeader.includes('SHA-256=')) {
+				const calculatedDigest = await createDigest(bodyText)
+				if (!digestHeader.includes(calculatedDigest)) {
+					logger.error(
+						`[Shared Inbox] Digest mismatch. Header: ${digestHeader}, Calculated: ${calculatedDigest}`
+					)
+					return c.json({ error: 'Invalid Digest' }, 400)
+				}
+			}
+
 			// Parse activity with error handling to prevent DoS from malformed JSON
 			let activity
 			try {
-				activity = (await c.req.json()) as unknown
+				activity = JSON.parse(bodyText) as unknown
 			} catch (error) {
 				// Only log full error details in development to avoid potential information disclosure
 				if (config.isDevelopment) {

--- a/src/tests/security_digest.test.ts
+++ b/src/tests/security_digest.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import activitypubApp from '../activitypub.js'
+import { handleActivity } from '../federation.js'
+import crypto from 'crypto'
+
+// Mock dependencies
+vi.mock('../lib/prisma.js', () => ({
+	prisma: {
+		user: {
+			findUnique: vi.fn(),
+		},
+		processedActivity: {
+			create: vi.fn(),
+		},
+	},
+}))
+
+// Mock verifySignature to always return true (simulating valid header signature)
+vi.mock('../lib/httpSignature.js', async () => {
+	const actual = await vi.importActual('../lib/httpSignature.js')
+	return {
+		...actual, // Keep createDigest and others
+		verifySignature: vi.fn().mockResolvedValue(true),
+	}
+})
+
+vi.mock('../federation.js', () => ({
+	handleActivity: vi.fn(),
+}))
+
+vi.mock('../lib/activitypubHelpers.js', () => ({
+	getBaseUrl: vi.fn(() => 'http://localhost:3000'),
+	createOrderedCollection: vi.fn(),
+	createOrderedCollectionPage: vi.fn(),
+}))
+
+vi.mock('../config.js', () => ({
+	config: {
+		isDevelopment: false,
+	},
+}))
+
+const app = new Hono()
+app.route('/', activitypubApp)
+
+describe('Security: Digest Verification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Ensure handleActivity returns a Promise to avoid 500 error
+		// @ts-ignore
+		handleActivity.mockResolvedValue(undefined)
+	})
+
+	it('should reject request when body does not match Digest header', async () => {
+		const bodyA = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://example.com/1',
+			type: 'Follow',
+			actor: 'https://example.com/users/alice',
+			object: 'https://example.com/users/bob',
+		})
+
+		const bodyB = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://example.com/1',
+			type: 'Create', // Maliciously changed type
+			actor: 'https://example.com/users/alice',
+			object: { type: 'Note', content: 'Spam' },
+		})
+
+		// Calculate digest for Body A
+		const hash = crypto.createHash('sha256').update(bodyA).digest('base64')
+		const digestA = `SHA-256=${hash}`
+
+		const res = await app.request('/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				Digest: digestA, // Claiming to be Body A
+				Signature:
+					'keyId="...",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="..."',
+				Date: new Date().toISOString(),
+				Host: 'localhost:3000',
+			},
+			body: bodyB, // Sending Body B
+		})
+
+		// If vulnerable, it returns 202 Accepted
+		// We want it to return 401 Unauthorized or 400 Bad Request
+		if (res.status === 202) {
+			console.log('VULNERABILITY CONFIRMED: Accepted mismatched digest')
+		}
+		expect(res.status).not.toBe(202)
+		expect(res.status).toBe(400)
+		const json = await res.json()
+		expect(json.error).toBe('Invalid Digest')
+	})
+})

--- a/src/tests/security_digest.test.ts
+++ b/src/tests/security_digest.test.ts
@@ -128,4 +128,55 @@ describe('Security: Digest Verification', () => {
 		expect(json.status).toBe('accepted')
 		expect(handleActivity).toHaveBeenCalled()
 	})
+
+	it('should accept request without Digest header', async () => {
+		const body = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://example.com/1',
+			type: 'Follow',
+			actor: 'https://example.com/users/alice',
+			object: 'https://example.com/users/bob',
+		})
+
+		const res = await app.request('/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				Signature:
+					'keyId="...",algorithm="rsa-sha256",headers="(request-target) host date",signature="..."',
+				Date: new Date().toISOString(),
+				Host: 'localhost:3000',
+			},
+			body: body,
+		})
+
+		expect(res.status).toBe(202)
+		expect(handleActivity).toHaveBeenCalled()
+	})
+
+	it('should ignore Digest header with unknown algorithm', async () => {
+		const body = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://example.com/1',
+			type: 'Follow',
+			actor: 'https://example.com/users/alice',
+			object: 'https://example.com/users/bob',
+		})
+
+		const res = await app.request('/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				Digest: 'MD5=xyz', // Unknown algorithm
+				Signature:
+					'keyId="...",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="..."',
+				Date: new Date().toISOString(),
+				Host: 'localhost:3000',
+			},
+			body: body,
+		})
+
+		expect(res.status).toBe(202)
+		expect(handleActivity).toHaveBeenCalled()
+	})
 })

--- a/src/tests/security_digest.test.ts
+++ b/src/tests/security_digest.test.ts
@@ -93,7 +93,39 @@ describe('Security: Digest Verification', () => {
 		}
 		expect(res.status).not.toBe(202)
 		expect(res.status).toBe(400)
-		const json = await res.json()
+		const json = (await res.json()) as { error: string }
 		expect(json.error).toBe('Invalid Digest')
+	})
+
+	it('should accept request when body matches Digest header', async () => {
+		const body = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://example.com/1',
+			type: 'Follow',
+			actor: 'https://example.com/users/alice',
+			object: 'https://example.com/users/bob',
+		})
+
+		// Calculate valid digest
+		const hash = crypto.createHash('sha256').update(body).digest('base64')
+		const digest = `SHA-256=${hash}`
+
+		const res = await app.request('/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				Digest: digest,
+				Signature:
+					'keyId="...",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="..."',
+				Date: new Date().toISOString(),
+				Host: 'localhost:3000',
+			},
+			body: body,
+		})
+
+		expect(res.status).toBe(202)
+		const json = (await res.json()) as { status: string }
+		expect(json.status).toBe('accepted')
+		expect(handleActivity).toHaveBeenCalled()
 	})
 })

--- a/src/tests/security_digest.test.ts
+++ b/src/tests/security_digest.test.ts
@@ -179,4 +179,32 @@ describe('Security: Digest Verification', () => {
 		expect(res.status).toBe(202)
 		expect(handleActivity).toHaveBeenCalled()
 	})
+
+	it('should handle request body reading failure', async () => {
+		const body = JSON.stringify({
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			type: 'Follow',
+		})
+
+		// Spy on Request.prototype.text to simulate failure
+		const textSpy = vi.spyOn(Request.prototype, 'text').mockRejectedValue(new Error('Read failed'))
+
+		const res = await app.request('/inbox', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/activity+json',
+				Signature:
+					'keyId="...",algorithm="rsa-sha256",headers="(request-target) host date",signature="..."',
+				Date: new Date().toISOString(),
+				Host: 'localhost:3000',
+			},
+			body: body,
+		})
+
+		expect(res.status).toBe(400)
+		const json = (await res.json()) as { error: string }
+		expect(json.error).toBe('Invalid request body')
+
+		textSpy.mockRestore()
+	})
 })


### PR DESCRIPTION
This commit addresses a security vulnerability where ActivityPub inbox handlers did not verify the Digest header against the request body, allowing potential body tampering.
- Implemented SHA-256 Digest verification in /users/:username/inbox and /inbox.
- Added src/tests/security_digest.test.ts to verify the fix and prevent regression.
- Recorded critical learning in .jules/sentinel.md.

---
*PR created automatically by Jules for task [3372391400031837522](https://jules.google.com/task/3372391400031837522) started by @burnoutberni*