### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -41,8 +41,8 @@ export function SearchBar() {
 			return
 		}
 
-		setIsLoading(true)
 		const timer = setTimeout(async () => {
+			setIsLoading(true)
 			try {
 				const data = await api.get<SearchResults>('/user-search', { q: query, limit: 5 })
 				setResults(data)
@@ -139,6 +139,13 @@ export function SearchBar() {
 	}
 
 	// Keyboard navigation
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		setResults(null)
+		inputRef.current?.focus()
+	}
+
 	const handleKeyDown = (e: KeyboardEvent) => {
 		if (!isOpen) {
 			return
@@ -176,7 +183,19 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const rightIcon = isLoading ? (
+		<Spinner size="sm" variant="secondary" />
+	) : query ? (
+		<button
+			onClick={handleClear}
+			aria-label="Clear search"
+			className="focus:outline-none"
+			type="button">
+			<CloseIcon className="w-5 h-5 text-text-tertiary hover:text-text-primary" />
+		</button>
+	) : (
+		undefined
+	)
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +208,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={rightIcon}
+				rightIconInteractive={!isLoading && Boolean(query)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,23 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should allow interaction with right icon when rightIconInteractive is true', () => {
+		const handleClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={
+					<button onClick={handleClick} aria-label="clear">
+						Clear
+					</button>
+				}
+				rightIconInteractive
+			/>
+		)
+
+		const button = screen.getByRole('button', { name: 'clear' })
+		fireEvent.click(button)
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Hoist mocks
+const { mockGet, mockPost } = vi.hoisted(() => {
+	return {
+		mockGet: vi.fn(),
+		mockPost: vi.fn(),
+	}
+})
+
+vi.mock('@/lib/api-client', () => ({
+	api: {
+		get: mockGet,
+		post: mockPost,
+	},
+}))
+
+describe('SearchBar', () => {
+	const { wrapper } = createTestWrapper()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockGet.mockResolvedValue({ users: [], events: [], remoteAccountSuggestion: null })
+	})
+
+	it('should render search input', () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/)
+		expect(input).toBeInTheDocument()
+	})
+
+	it('should show clear button when typing', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		expect(input).toHaveValue('test')
+		expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+	})
+
+	it('should clear input when clear button is clicked', async () => {
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+		const clearButton = screen.getByLabelText('Clear search')
+
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+		expect(input).toHaveFocus()
+	})
+
+	it('should show spinner when searching', async () => {
+		// Mock API to delay response
+		mockGet.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ users: [], events: [], remoteAccountSuggestion: null }), 100)))
+
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		// Wait for debounce (300ms) to trigger search
+		await waitFor(() => {
+             expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+        }, { timeout: 1000 })
+	})
+})


### PR DESCRIPTION
💡 What: Added a clear (X) button to the SearchBar that appears when there is text.
🎯 Why: Users had to manually delete text to clear the search, which is tedious.
📸 Before/After: Added a "X" icon inside the input that clears the text and refocuses the input.
♿ Accessibility: The clear button is keyboard accessible (tabbable) and has an aria-label "Clear search".
Tests: Added unit tests for Input interactive icon and SearchBar clear functionality. Verified with Playwright.

---
*PR created automatically by Jules for task [2919224496325193989](https://jules.google.com/task/2919224496325193989) started by @burnoutberni*