### PR TITLE
🎨 Palette: Add clear button to SearchBar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -41,8 +41,8 @@ export function SearchBar() {
 			return
 		}
 
-		setIsLoading(true)
 		const timer = setTimeout(async () => {
+			setIsLoading(true)
 			try {
 				const data = await api.get<SearchResults>('/user-search', { q: query, limit: 5 })
 				setResults(data)
@@ -178,6 +178,22 @@ export function SearchBar() {
 
 	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
 
+	const handleClear = () => {
+		setQuery('')
+		inputRef.current?.focus()
+	}
+
+	const clearButton =
+		query && !isLoading ? (
+			<button
+				type="button"
+				onClick={handleClear}
+				className="p-1 hover:bg-neutral-100 rounded-full dark:hover:bg-neutral-800 transition-colors text-text-secondary"
+				aria-label="Clear search">
+				<CloseIcon className="w-4 h-4" />
+			</button>
+		) : undefined
+
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
 			<Input
@@ -189,7 +205,8 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={loadingSpinner || clearButton}
+				rightIconInteractive={!!clearButton}
 				className="w-full"
 			/>
 

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -206,7 +206,7 @@ export function SearchBar() {
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
 				rightIcon={loadingSpinner || clearButton}
-				rightIconInteractive={!!clearButton}
+				rightIconInteractive={Boolean(clearButton)}
 				className="w-full"
 			/>
 

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -35,6 +35,10 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 	 */
 	rightIcon?: React.ReactNode
 	/**
+	 * Whether the right icon should be interactive (clickable)
+	 */
+	rightIconInteractive?: boolean
+	/**
 	 * Whether the input should take full width of its container
 	 */
 	fullWidth?: boolean
@@ -55,6 +59,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			helperText,
 			leftIcon,
 			rightIcon,
+			rightIconInteractive = false,
 			fullWidth = false,
 			className,
 			id,
@@ -157,7 +162,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 							className={cn(
 								'absolute right-3 top-1/2 -translate-y-1/2',
 								'text-text-disabled',
-								'pointer-events-none',
+								!rightIconInteractive && 'pointer-events-none',
 								error && 'text-error-500 dark:text-error-400'
 							)}>
 							{rightIcon}

--- a/client/src/tests/components/Input.test.tsx
+++ b/client/src/tests/components/Input.test.tsx
@@ -147,4 +147,23 @@ describe('Input Component', () => {
 		const label = screen.getByText('Email')
 		expect(label).toHaveAttribute('for', 'custom-id')
 	})
+
+	it('should allow interaction with right icon when rightIconInteractive is true', () => {
+		const handleIconClick = vi.fn()
+		render(
+			<Input
+				type="text"
+				rightIcon={
+					<button onClick={handleIconClick} data-testid="right-icon-btn">
+						Click me
+					</button>
+				}
+				rightIconInteractive
+			/>
+		)
+
+		const button = screen.getByTestId('right-icon-btn')
+		fireEvent.click(button)
+		expect(handleIconClick).toHaveBeenCalledTimes(1)
+	})
 })

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SearchBar } from '../../components/SearchBar'
 import { createTestWrapper } from '../testUtils'
 

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Mock api client
+vi.mock('../../lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('renders correctly', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		expect(
+			screen.getByPlaceholderText('Search events, users, or @user@domain...')
+		).toBeInTheDocument()
+	})
+
+	it('updates query on input change', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+		fireEvent.change(input, { target: { value: 'test' } })
+		expect(input).toHaveValue('test')
+	})
+
+	it('shows clear button when text is entered', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+
+		// Initially no clear button
+		expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+
+		// Enter text
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		const clearButton = screen.getByLabelText('Clear search')
+		expect(clearButton).toBeInTheDocument()
+	})
+
+	it('clears search and focuses input when clear button is clicked', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText('Search events, users, or @user@domain...')
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		const clearButton = screen.getByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+	})
+})


### PR DESCRIPTION
This PR adds a "Clear" button to the SearchBar component, allowing users to easily clear their search query. It also improves the UX by adjusting the debounce logic so the loading spinner doesn't appear immediately upon typing, keeping the clear button accessible.

**Changes:**
- `client/src/components/ui/Input.tsx`: Added `rightIconInteractive` prop.
- `client/src/components/SearchBar.tsx`: Added clear button logic and optimized debounce.
- `client/src/tests/components/Input.test.tsx`: Added test for interactive right icon.
- `client/src/tests/components/SearchBar.test.tsx`: Added new tests for SearchBar functionality.

**Verification:**
- Unit tests passed.
- Frontend verification with Playwright confirmed the clear button appears and works correctly.

---
*PR created automatically by Jules for task [10657834727222433061](https://jules.google.com/task/10657834727222433061) started by @burnoutberni*