### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing in rate limit middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-25 - Rate Limit IP Spoofing
+**Vulnerability:** The rate limiter was using the first IP in `X-Forwarded-For`, allowing attackers to spoof their IP by sending a custom header which would be prepended to the real IP by the proxy.
+**Learning:** When behind a trusted proxy (like Caddy), the `X-Forwarded-For` header contains a list of IPs. The *last* added IP is the most trustworthy one if we trust the proxy chain. The client-provided header is at the beginning.
+**Prevention:** Always use the last IP in `X-Forwarded-For` when behind a trusted proxy, or use a library that handles this trust chain correctly.

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -86,7 +86,9 @@ export function rateLimit(config: Partial<RateLimitConfig> = {}) {
 		// Generate rate limit key
 		const userId = c.get('userId') as string | undefined
 		const ip =
-			c.req.header('x-forwarded-for')?.split(',')[0] || c.req.header('x-real-ip') || 'unknown'
+			c.req.header('x-forwarded-for')?.split(',').pop()?.trim() ||
+			c.req.header('x-real-ip') ||
+			'unknown'
 
 		let key: string
 		if (finalConfig.keyGenerator) {

--- a/src/tests/middleware/rateLimit.test.ts
+++ b/src/tests/middleware/rateLimit.test.ts
@@ -186,7 +186,7 @@ describe('Rate Limiting Middleware', () => {
 
 			// Should be blocked because realIp matches the first request
 			await expect(middleware(mockContext, mockNext)).rejects.toThrow(
-				Errors.tooManyRequests('').constructor
+				'Rate limit exceeded'
 			)
 		})
 

--- a/src/tests/middleware/rateLimit.test.ts
+++ b/src/tests/middleware/rateLimit.test.ts
@@ -162,18 +162,32 @@ describe('Rate Limiting Middleware', () => {
 			expect(mockNext).toHaveBeenCalled()
 		})
 
-		it('should handle x-forwarded-for with multiple IPs', async () => {
-			const middleware = rateLimit({ windowMs: 1000, maxRequests: 5 })
+		it('should use the LAST IP in x-forwarded-for to prevent spoofing', async () => {
+			const middleware = rateLimit({ windowMs: 60000, maxRequests: 1 })
+			const realIp = '203.0.113.1'
+			const spoofedIp = '198.51.100.1'
 
 			mockRequest.header.mockImplementation((name: string) => {
-				if (name === 'x-forwarded-for') return `${uniqueIp}, 10.0.0.1`
+				if (name === 'x-forwarded-for') return `${spoofedIp}, ${realIp}`
 				return undefined
 			})
 			mockContext.get = vi.fn().mockReturnValue(undefined)
 
+			// First request
 			await middleware(mockContext, mockNext)
+			expect(mockNext).toHaveBeenCalledTimes(1)
 
-			expect(mockNext).toHaveBeenCalled()
+			// Second request with DIFFERENT spoofed IP but SAME real IP
+			const newSpoofedIp = '198.51.100.2'
+			mockRequest.header.mockImplementation((name: string) => {
+				if (name === 'x-forwarded-for') return `${newSpoofedIp}, ${realIp}`
+				return undefined
+			})
+
+			// Should be blocked because realIp matches the first request
+			await expect(middleware(mockContext, mockNext)).rejects.toThrow(
+				Errors.tooManyRequests('').constructor
+			)
 		})
 
 		it('should reset counter after window expires', async () => {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix IP spoofing in rate limiter

🚨 Severity: HIGH
💡 Vulnerability: The rate limiter used the first IP in `X-Forwarded-For`, allowing attackers to spoof their IP.
🎯 Impact: Attackers could bypass rate limits by rotating a fake `X-Forwarded-For` header.
🔧 Fix: Updated middleware to use the last IP in `X-Forwarded-For`, which is the one appended by the trusted proxy.
✅ Verification: Added a test case in `src/tests/middleware/rateLimit.test.ts` that simulates an attacker sending a spoofed header and verifies that the rate limiter correctly identifies the real IP (appended by the proxy) and blocks the request.

---
*PR created automatically by Jules for task [2510591614697791216](https://jules.google.com/task/2510591614697791216) started by @burnoutberni*