### PR TITLE
🎨 Palette: Add Clear Button to Search Bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-02 - Interactive Input Icons
+**Learning:** The `Input` component sets `pointer-events-none` on the `rightIcon` container. To make an icon interactive (like a clear button), apply `pointer-events-auto` to the button/icon element itself.
+**Action:** Use `pointer-events-auto` on interactive children passed to `rightIcon` prop.

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { SearchIcon, Button, Input, Spinner, GlobeIcon } from '@/components/ui'
+import { SearchIcon, Button, Input, Spinner, GlobeIcon, CloseIcon } from '@/components/ui'
 import { useThemeColors } from '@/design-system'
 import { api } from '@/lib/api-client'
 import { createLogger } from '@/lib/logger'
@@ -176,7 +176,21 @@ export function SearchBar() {
 
 	const searchIcon = <SearchIcon className="w-5 h-5" />
 
-	const loadingSpinner = isLoading ? <Spinner size="sm" variant="secondary" /> : undefined
+	const handleClear = () => {
+		setQuery('')
+		setIsOpen(false)
+		inputRef.current?.focus()
+	}
+
+	const clearButton = (
+		<button
+			type="button"
+			onClick={handleClear}
+			className="text-text-secondary hover:text-text-primary focus:outline-none focus:text-text-primary p-1 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors pointer-events-auto"
+			aria-label="Clear search">
+			<CloseIcon className="w-4 h-4" />
+		</button>
+	)
 
 	return (
 		<div ref={searchRef} className="relative w-full max-w-md">
@@ -189,7 +203,13 @@ export function SearchBar() {
 				onFocus={() => query && setIsOpen(true)}
 				placeholder="Search events, users, or @user@domain..."
 				leftIcon={searchIcon}
-				rightIcon={loadingSpinner}
+				rightIcon={
+					isLoading ? (
+						<Spinner size="sm" variant="secondary" />
+					) : query ? (
+						clearButton
+					) : undefined
+				}
 				className="w-full"
 			/>
 

--- a/client/src/tests/components/SearchBar.test.tsx
+++ b/client/src/tests/components/SearchBar.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { SearchBar } from '../../components/SearchBar'
+import { createTestWrapper } from '../testUtils'
+
+// Mock api
+vi.mock('../../lib/api-client', () => ({
+	api: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}))
+
+describe('SearchBar', () => {
+	it('renders the search input', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		expect(screen.getByPlaceholderText(/Search events, users/i)).toBeInTheDocument()
+	})
+
+	it('does not show clear button initially', () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		// Clear button should not be present (aria-label="Clear search")
+		expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+	})
+
+	it('updates query when typing', async () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test query' } })
+
+		expect(input).toHaveValue('test query')
+	})
+
+	it('shows clear button when text is typed', async () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await waitFor(() => {
+			expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+		})
+	})
+
+	it('clears query and focuses input when clear button is clicked', async () => {
+		const { wrapper } = createTestWrapper()
+		render(<SearchBar />, { wrapper })
+		const input = screen.getByPlaceholderText(/Search events, users/i)
+
+		fireEvent.change(input, { target: { value: 'test' } })
+
+		await waitFor(() => {
+			expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+		})
+
+		const clearButton = screen.getByLabelText('Clear search')
+		fireEvent.click(clearButton)
+
+		expect(input).toHaveValue('')
+		expect(input).toHaveFocus()
+	})
+})


### PR DESCRIPTION
Added a clear button to the `SearchBar` component to improve UX. Users can now easily clear the search query with a single click. The button is accessible and keyboard-friendly. Added unit tests to verify the behavior.

---
*PR created automatically by Jules for task [3867824331915879161](https://jules.google.com/task/3867824331915879161) started by @burnoutberni*